### PR TITLE
Fix Spotify scope string and add test

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -34,7 +34,7 @@ class Config:
         "user-top-read",                   # Read user's favorite songs/artists
         "playlist-read-private",           # Read user's private playlists
         "playlist-read-collaborative",     # Read collaborative playlists
-        "playlist - modify - private",     # Modify private playlists
+        "playlist-modify-private",        # Modify private playlists
         "user-library-read",               # Read user's library (likes)
         "user-library-modify"              # Modify user's library (like/unlike)
     ] 

--- a/test_config_scopes.py
+++ b/test_config_scopes.py
@@ -1,0 +1,7 @@
+import pytest
+from src.config import Config
+
+
+def test_playlist_modify_private_scope_present():
+    assert "playlist-modify-private" in Config.SPOTIFY_SCOPES
+    assert all(" - " not in scope for scope in Config.SPOTIFY_SCOPES)


### PR DESCRIPTION
## Summary
- correct typo in SPOTIFY_SCOPES for playlist modification
- add test ensuring expected scopes and no malformed names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e760f44c832c9d7b7729d080e0ad