### PR TITLE
Translate Spanish comments and logs in mcp_stdio_server

### DIFF
--- a/src/mcp_stdio_server.py
+++ b/src/mcp_stdio_server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Servidor MCP para Spotify Player usando stdio
-Implementa el protocolo MCP sobre JSON-RPC para comunicación con Cursor
+MCP server for Spotify Player using stdio
+Implements the MCP protocol over JSON-RPC for communication with Cursor
 """
 
 import json
@@ -11,7 +11,7 @@ from typing import Dict, Any, Optional
 from src.config import Config
 from src.spotify_controller import SpotifyController
 
-# Configurar logging
+# Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -21,46 +21,46 @@ class MCPServer:
         self.controller = SpotifyController()
         self.request_id = 0
         
-        # Manifiesto MCP
+        # MCP Manifest
         self.manifest = {
             "schema_url": "https://json-schema.org/draft/2020-12/schema",
             "nameForHuman": "Spotify Player",
             "nameForModel": "spotify_player",
-            "descriptionForHuman": "Controla tu música de Spotify usando comandos naturales",
-            "descriptionForModel": "Herramienta para controlar la reproducción de música en Spotify. Puedes reproducir canciones, pausar, saltar, cambiar volumen, buscar música y más.",
+            "descriptionForHuman": "Control your Spotify music using natural commands",
+            "descriptionForModel": "Tool for controlling music playback on Spotify. You can play songs, pause, skip, adjust volume, search for music, and more.",
             "auth": {
                 "type": "oauth",
-                "instructions": "Necesitas autenticarte con Spotify para usar esta herramienta"
+                "instructions": "You need to authenticate with Spotify to use this tool"
             },
             "tools": [
                 {
                     "name": "play_music",
-                    "description": "Reproduce música en Spotify. Puedes especificar una canción, artista, playlist o simplemente reanudar la reproducción.",
+                    "description": "Play music on Spotify. You can specify a song, artist, playlist or simply resume playback.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
                             "query": {
                                 "type": "string",
-                                "description": "Búsqueda de canción o artista (ej: 'REM', 'Bohemian Rhapsody')"
+                                "description": "Song or artist search (e.g., 'REM', 'Bohemian Rhapsody')"
                             },
                             "playlist_name": {
                                 "type": "string",
-                                "description": "Nombre de la playlist a reproducir"
+                                  "description": "Name of the playlist to play"
                             },
                             "track_uri": {
                                 "type": "string",
-                                "description": "URI específica de la canción"
+                                  "description": "Specific track URI"
                             },
                             "artist_uri": {
                                 "type": "string",
-                                "description": "URI específica del artista"
+                                  "description": "Specific artist URI"
                             }
                         }
                     }
                 },
                 {
                     "name": "pause_music",
-                    "description": "Pausa la reproducción actual de música",
+                    "description": "Pause the current music playback",
                     "inputSchema": {
                         "type": "object",
                         "properties": {}
@@ -68,7 +68,7 @@ class MCPServer:
                 },
                 {
                     "name": "skip_next",
-                    "description": "Salta a la siguiente canción en la cola de reproducción",
+                    "description": "Skip to the next song in the playback queue",
                     "inputSchema": {
                         "type": "object",
                         "properties": {}
@@ -76,7 +76,7 @@ class MCPServer:
                 },
                 {
                     "name": "skip_previous",
-                    "description": "Salta a la canción anterior en la cola de reproducción",
+                    "description": "Skip to the previous song in the playback queue",
                     "inputSchema": {
                         "type": "object",
                         "properties": {}
@@ -84,7 +84,7 @@ class MCPServer:
                 },
                 {
                     "name": "set_volume",
-                    "description": "Establece el volumen de reproducción (0-100%)",
+                    "description": "Set the playback volume (0-100%)",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -92,7 +92,7 @@ class MCPServer:
                                 "type": "integer",
                                 "minimum": 0,
                                 "maximum": 100,
-                                "description": "Volumen entre 0 y 100"
+                                "description": "Volume between 0 and 100"
                             }
                         },
                         "required": ["volume_percent"]
@@ -100,7 +100,7 @@ class MCPServer:
                 },
                 {
                     "name": "get_current_playing",
-                    "description": "Obtiene información sobre la canción actualmente reproduciéndose",
+                    "description": "Retrieve information about the currently playing song",
                     "inputSchema": {
                         "type": "object",
                         "properties": {}
@@ -108,7 +108,7 @@ class MCPServer:
                 },
                 {
                     "name": "get_playback_state",
-                    "description": "Obtiene el estado completo de reproducción incluyendo dispositivo, volumen, etc.",
+                    "description": "Retrieve the full playback state including device, volume, etc.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {}
@@ -116,26 +116,26 @@ class MCPServer:
                 },
                 {
                     "name": "search_music",
-                    "description": "Busca música en Spotify por canción, artista o álbum",
+                    "description": "Search for music on Spotify by track, artist, or album",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
                             "query": {
                                 "type": "string",
-                                "description": "Término de búsqueda"
+                                  "description": "Search term"
                             },
                             "search_type": {
                                 "type": "string",
                                 "enum": ["track", "artist", "album"],
                                 "default": "track",
-                                "description": "Tipo de búsqueda"
+                                  "description": "Search type"
                             },
                             "limit": {
                                 "type": "integer",
                                 "minimum": 1,
                                 "maximum": 50,
                                 "default": 10,
-                                "description": "Número máximo de resultados"
+                                  "description": "Maximum number of results"
                             }
                         },
                         "required": ["query"]
@@ -143,7 +143,7 @@ class MCPServer:
                 },
                 {
                     "name": "get_playlists",
-                    "description": "Obtiene la lista de playlists del usuario",
+                    "description": "Retrieve the user's playlists list",
                     "inputSchema": {
                         "type": "object",
                         "properties": {}
@@ -151,11 +151,11 @@ class MCPServer:
                 },
                 {
                     "name": "get_playlist_tracks",
-                    "description": "Obtiene las canciones de una playlist dada",
+                    "description": "Retrieve tracks from a given playlist",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "playlist_id": {"type": "string", "description": "ID de la playlist"},
+                            "playlist_id": {"type": "string", "description": "Playlist ID"},
                             "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20}
                         },
                         "required": ["playlist_id"]
@@ -165,17 +165,17 @@ class MCPServer:
         }
 
     def send_response(self, response: Dict[str, Any]):
-        """Envía una respuesta JSON-RPC por stdout"""
+        """Send a JSON-RPC response over stdout"""
         json_response = json.dumps(response, ensure_ascii=False) + "\n"
         sys.stdout.write(json_response)
         sys.stdout.flush()
-        logger.info(f"Enviando respuesta: {response}")
+        logger.info(f"Sending response: {response}")
 
     def send_error(self, request_id: Any, code: int, message: str):
-        """Envía un error JSON-RPC"""
-        # Manejar el caso donde request_id es None
+        """Send a JSON-RPC error"""
+        # Handle the case where request_id is None
         if request_id is None:
-            return  # No enviar respuesta para notificaciones sin ID
+            return  # Do not send a response for notifications without ID
         
         error_response = {
             "jsonrpc": "2.0",
@@ -188,7 +188,7 @@ class MCPServer:
         self.send_response(error_response)
 
     def handle_initialize(self, request_id: Any, params: Dict[str, Any]):
-        """Maneja la inicialización del cliente MCP"""
+        """Handle MCP client initialization"""
         response = {
             "jsonrpc": "2.0",
             "id": request_id,
@@ -206,7 +206,7 @@ class MCPServer:
         self.send_response(response)
 
     def handle_tools_list(self, request_id: Any):
-        """Lista las herramientas disponibles"""
+        """List available tools"""
         response = {
             "jsonrpc": "2.0",
             "id": request_id,
@@ -217,14 +217,14 @@ class MCPServer:
         self.send_response(response)
 
     def handle_tools_call(self, request_id: Any, params: Dict[str, Any]):
-        """Ejecuta una herramienta"""
+        """Execute a tool"""
         try:
-            # Manejar tanto formato de array como formato directo
+            # Handle both array and direct formats
             if "calls" in params:
-                # Formato: {"calls": [{"name": "...", "arguments": {...}}]}
+                # Format: {"calls": [{"name": "...", "arguments": {...}}]}
                 calls = params.get("calls", [])
             else:
-                # Formato: {"name": "...", "arguments": {...}}
+                # Format: {"name": "...", "arguments": {...}}
                 calls = [{"name": params.get("name"), "arguments": params.get("arguments", {})}]
             
             results = []
@@ -236,29 +236,29 @@ class MCPServer:
                 if not tool_name:
                     continue
                 
-                # Verificar autenticación para comandos que la requieren
-                if tool_name in ["play_music", "pause_music", "skip_next", "skip_previous", 
+                # Check authentication for commands that require it
+                if tool_name in ["play_music", "pause_music", "skip_next", "skip_previous",
                                "set_volume", "get_current_playing", "get_playback_state","get_playlist_tracks"]:
-                    logger.info(f"Verificando autenticación para {tool_name}")
+                    logger.info(f"Checking authentication for {tool_name}")
                     if not self.controller.is_authenticated():
-                        logger.warning(f"No autenticado para {tool_name}")
+                        logger.warning(f"Not authenticated for {tool_name}")
                         results.append({
                             "name": tool_name,
                             "content": [
                                 {
                                     "type": "text",
-                                    "text": "No autenticado con Spotify. Necesitas autenticarte primero."
+                                    "text": "Not authenticated with Spotify. You need to authenticate first."
                                 }
                             ]
                         })
                         continue
                     else:
-                        logger.info(f"Autenticado correctamente para {tool_name}")
+                        logger.info(f"Authenticated successfully for {tool_name}")
                 
-                # Ejecutar el comando
-                logger.info(f"Ejecutando {tool_name} con argumentos: {arguments}")
+                # Execute the command
+                logger.info(f"Executing {tool_name} with arguments: {arguments}")
                 result = self.execute_tool(tool_name, arguments)
-                logger.info(f"Resultado de {tool_name}: {result}")
+                logger.info(f"Result of {tool_name}: {result}")
                 results.append({
                     "name": tool_name,
                     "content": [
@@ -287,11 +287,11 @@ class MCPServer:
             self.send_response(response)
             
         except Exception as e:
-            logger.error(f"Error ejecutando herramienta: {str(e)}")
-            self.send_error(request_id, -32603, f"Error interno: {str(e)}")
+            logger.error(f"Error executing tool: {str(e)}")
+            self.send_error(request_id, -32603, f"Internal error: {str(e)}")
 
     def execute_tool(self, tool_name: str, arguments: Dict[str, Any]) -> str:
-        """Ejecuta una herramienta específica"""
+        """Execute a specific tool"""
         try:
             if tool_name == "play_music":
                 result = self.controller.play_music(
@@ -301,40 +301,40 @@ class MCPServer:
                     artist_uri=arguments.get("artist_uri")
                 )
                 if result.get('success'):
-                    return f"{result.get('message', 'Reproducción iniciada')}"
+                    return f"{result.get('message', 'Playback started')}"
                 else:
-                    return f"{result.get('message', 'No se pudo reproducir la música')}"
+                    return f"{result.get('message', 'Could not play music')}"
             
             elif tool_name == "pause_music":
                 result = self.controller.pause_music()
                 if result.get('success'):
-                    return f"{result.get('message', 'Reproducción pausada')}"
+                    return f"{result.get('message', 'Playback paused')}"
                 else:
-                    return f"{result.get('message', 'No se pudo pausar')}"
+                    return f"{result.get('message', 'Could not pause')}"
             
             elif tool_name == "skip_next":
                 result = self.controller.skip_next()
                 if result.get('success'):
-                    return f"{result.get('message', 'Saltando a la siguiente canción')}"
+                    return f"{result.get('message', 'Skipping to the next song')}"
                 else:
-                    return f"{result.get('message', 'No se pudo saltar')}"
+                    return f"{result.get('message', 'Could not skip')}"
             
             elif tool_name == "skip_previous":
                 result = self.controller.skip_previous()
                 if result.get('success'):
-                    return f"{result.get('message', 'Saltando a la canción anterior')}"
+                    return f"{result.get('message', 'Skipping to the previous song')}"
                 else:
-                    return f"{result.get('message', 'No se pudo saltar')}"
+                    return f"{result.get('message', 'Could not skip')}"
             
             elif tool_name == "set_volume":
                 volume = arguments.get("volume_percent")
                 if volume is None:
-                    raise ValueError("volume_percent es requerido")
+                    raise ValueError("volume_percent is required")
                 result = self.controller.set_volume(volume)
                 if result.get('success'):
-                    return f"{result.get('message', f'Volumen establecido al {volume}%')}"
+                    return f"{result.get('message', f'Volume set to {volume}%')}"
                 else:
-                    return f"{result.get('message', 'No se pudo cambiar el volumen')}"
+                    return f"{result.get('message', 'Could not change volume')}"
             
             elif tool_name == "get_current_playing":
                 result = self.controller.get_current_playing()
@@ -342,15 +342,15 @@ class MCPServer:
                     track = result.get('track', {})
                     is_playing = result.get('is_playing', False)
                     progress_ms = result.get('progress_ms', 0)
-                    
+
                     if track:
-                        status = "Reproduciendo" if is_playing else "Pausado"
-                        logger.info("Debug: ejecutando get_current_playing")
-                        return f"{status}: {track.get('name', 'Desconocida')} por {track.get('artist', 'Desconocido')}"
+                        status = "Playing" if is_playing else "Paused"
+                        logger.info("Debug: running get_current_playing")
+                        return f"{status}: {track.get('name', 'Unknown')} by {track.get('artist', 'Unknown')}"
                     else:
-                        return "No hay música reproduciéndose actualmente"
+                        return "No music is currently playing"
                 else:
-                    return f"No se pudo obtener información: {result.get('message', 'Error desconocido')}"
+                    return f"Could not retrieve information: {result.get('message', 'Unknown error')}"
             
             elif tool_name == "get_playback_state":
                 result = self.controller.get_playback_state()
@@ -359,21 +359,21 @@ class MCPServer:
                     current_track = state.get('current_track', {})
                     is_playing = state.get('is_playing', False)
                     volume = state.get('volume_percent', 0)
-                    device = state.get('device_name', 'Desconocido')
-                    
+                    device = state.get('device_name', 'Unknown')
+
                     if current_track:
-                        status = "Reproduciendo" if is_playing else "Pausado"
-                        track_info = f"{current_track.get('name', 'Desconocida')} - {current_track.get('artist', 'Desconocido')}"
-                        return f"{status}: {track_info} | Volumen: {volume}% | Dispositivo: {device}"
+                        status = "Playing" if is_playing else "Paused"
+                        track_info = f"{current_track.get('name', 'Unknown')} - {current_track.get('artist', 'Unknown')}"
+                        return f"{status}: {track_info} | Volume: {volume}% | Device: {device}"
                     else:
-                        return f"No hay música reproduciéndose | Volumen: {volume}% | Dispositivo: {device}"
+                        return f"No music playing | Volume: {volume}% | Device: {device}"
                 else:
-                    return f"No se pudo obtener el estado: {result.get('message', 'Error desconocido')}"
+                    return f"Could not retrieve state: {result.get('message', 'Unknown error')}"
             
             elif tool_name == "search_music":
                 query = arguments.get("query")
                 if not query:
-                    raise ValueError("query es requerido")
+                    raise ValueError("query is required")
                 result = self.controller.search_music(
                     query=query,
                     search_type=arguments.get("search_type", "track"),
@@ -385,12 +385,12 @@ class MCPServer:
                     if tracks:
                         track_list = []
                         for i, track in enumerate(tracks[:5], 1):
-                            track_list.append(f"{i}. {track.get('name', 'Desconocida')} - {track.get('artist', 'Desconocido')}")
-                        return f"Encontradas {len(tracks)} canciones para '{query}' (de {total} total):\n" + "\n".join(track_list)
+                            track_list.append(f"{i}. {track.get('name', 'Unknown')} - {track.get('artist', 'Unknown')}")
+                        return f"Found {len(tracks)} songs for '{query}' (of {total} total):\n" + "\n".join(track_list)
                     else:
-                        return f"No se encontraron canciones para '{query}'"
+                        return f"No songs found for '{query}'"
                 else:
-                    return f"Error en la búsqueda: {result.get('message', 'Error desconocido')}"
+                    return f"Search error: {result.get('message', 'Unknown error')}"
             
             elif tool_name == "get_playlists":
                 result = self.controller.get_playlists()
@@ -400,19 +400,19 @@ class MCPServer:
                     if playlists:
                         playlist_list = []
                         for i, playlist in enumerate(playlists, 1):
-                            playlist_list.append(f"{i}. {playlist.get('name', 'Desconocida')} ({playlist.get('track_count', 0)} canciones)")
-                            playlist_list.append(f"{i}. {playlist.get('name', 'Desconocida')} ({playlist.get('track_count', 0)} canciones) - ID: {playlist.get('id')}")
-                        return f"Encontradas {len(playlists)} playlists (de {total} total):\n" + "\n".join(playlist_list)
+                            playlist_list.append(f"{i}. {playlist.get('name', 'Unknown')} ({playlist.get('track_count', 0)} songs)")
+                            playlist_list.append(f"{i}. {playlist.get('name', 'Unknown')} ({playlist.get('track_count', 0)} songs) - ID: {playlist.get('id')}")
+                        return f"Found {len(playlists)} playlists (of {total} total):\n" + "\n".join(playlist_list)
                     else:
-                        return f"No se encontraron playlists"
+                        return "No playlists found"
                 else:
-                    return f"Error obteniendo playlists: {result.get('message', 'Error desconocido')}"
+                    return f"Error fetching playlists: {result.get('message', 'Unknown error')}"
             elif tool_name == "get_playlist_tracks":
                 playlist_id = arguments.get("playlist_id")
                 if not playlist_id:
                     raise ValueError("playlist_id is required")
 
-                # Validdate if playlist_id is a valid Spotify ID
+                # Validate if playlist_id is a valid Spotify ID
                 if playlist_id.isdigit() and len(playlist_id) < 10:  # Most likely is an index not a real ID
                     return "Error: The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes."
 
@@ -424,72 +424,72 @@ class MCPServer:
                     if tracks:
                         track_list = []
                         for i, track in enumerate(tracks[:5], 1):
-                            track_list.append(f"{i}. {track.get('name', 'Desconocida')} - {track.get('artist', 'Desconocido')}")
-                        return f"Encontradas {len(tracks)} canciones en la playlist (de {total} total):\n" + "\n".join(track_list)
+                            track_list.append(f"{i}. {track.get('name', 'Unknown')} - {track.get('artist', 'Unknown')}")
+                        return f"Found {len(tracks)} tracks in the playlist (of {total} total):\n" + "\n".join(track_list)
                     else:
-                        return f"No se encontraron canciones en la playlist"
+                        return "No tracks found in the playlist"
                 else:
-                    return f"Error obteniendo canciones de la playlist: {result.get('message', 'Error desconocido')}"
+                    return f"Error fetching playlist tracks: {result.get('message', 'Unknown error')}"
             
             else:
-                raise ValueError(f"Herramienta '{tool_name}' no soportada")
+                raise ValueError(f"Tool '{tool_name}' not supported")
                 
         except Exception as e:
-            logger.error(f"Error ejecutando {tool_name}: {str(e)}")
+            logger.error(f"Error executing {tool_name}: {str(e)}")
             return f"Error: {str(e)}"
 
     def run(self):
-        """Ejecuta el servidor MCP"""
-        logger.info("Iniciando servidor MCP Spotify Player...")
+        """Run the MCP server"""
+        logger.info("Starting MCP Spotify Player server...")
         
         try:
             while True:
-                # Leer línea de stdin
+                # Read line from stdin
                 line = sys.stdin.readline()
                 if not line:
                     break
                 
                 try:
-                    # Parsear JSON-RPC
+                    # Parse JSON-RPC
                     request = json.loads(line.strip())
                     method = request.get("method")
                     request_id = request.get("id")
                     params = request.get("params", {})
                     
-                    logger.info(f"Recibido: {method}")
+                    logger.info(f"Received: {method}")
                     
-                    # Manejar métodos MCP
+                    # Handle MCP methods
                     if method == "initialize":
                         self.handle_initialize(request_id, params)
                     elif method == "notifications/initialized":
-                        # No hacer nada para notificaciones de inicialización
-                        logger.info("Cliente inicializado correctamente")
+                        # No action for initialization notifications
+                        logger.info("Client initialized successfully")
                     elif method == "tools/list":
                         self.handle_tools_list(request_id)
                     elif method == "tools/call":
                         self.handle_tools_call(request_id, params)
                     elif method in ["resources/list", "prompts/list"]:
-                        # Métodos opcionales que no implementamos
-                        logger.info(f"Método opcional no implementado: {method}")
+                        # Optional methods not implemented
+                        logger.info(f"Optional method not implemented: {method}")
                         if request_id is not None:
-                            self.send_error(request_id, -32601, f"Método '{method}' no implementado")
+                            self.send_error(request_id, -32601, f"Method '{method}' not implemented")
                     else:
-                        logger.warning(f"Método no soportado: {method}")
+                        logger.warning(f"Unsupported method: {method}")
                         if request_id is not None:
-                            self.send_error(request_id, -32601, f"Método '{method}' no soportado")
+                            self.send_error(request_id, -32601, f"Method '{method}' not supported")
                         
                 except json.JSONDecodeError as e:
-                    logger.error(f"Error parseando JSON: {e}")
+                    logger.error(f"Error parsing JSON: {e}")
                     continue
                 except Exception as e:
-                    logger.error(f"Error procesando petición: {e}")
+                    logger.error(f"Error processing request: {e}")
                     continue
                     
         except KeyboardInterrupt:
-            logger.info("Servidor detenido por el usuario")
+            logger.info("Server stopped by the user")
         except Exception as e:
-            logger.error(f"Error en el servidor: {e}")
+            logger.error(f"Server error: {e}")
 
 if __name__ == "__main__":
     server = MCPServer()
-    server.run() 
+    server.run()


### PR DESCRIPTION
## Summary
- Translate MCP server docstrings, comments, and log messages from Spanish to English
- Update manifest descriptions and tool documentation to English
- Clarify authentication checks and runtime logging for the Spotify Player server

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896fcad4940832ca50db95d5357345c