### PR TITLE
Add playlist clearing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Control your Spotify music from Claude using the MCP (Model Context Protocol).
 - **Playback control**: Play, pause, skip songs
 - **Volume control**: Adjust volume from 0 to 100%
 - **Music search**: Search for songs, artists, and albums
-- **Playlist management**: List and play your playlists
+- **Playlist management**: List, rename and clear your playlists
 - **Integration with Claude**: Use natural commands to control your music
 
 ## 📋 Requirements

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -164,6 +164,20 @@ MCP_MANIFEST = {
                 "type": "object",
                 "properties": {}
             }
+        },
+        {
+            "name": "clear_playlist",
+            "description": "Remove all tracks from a Spotify playlist",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "playlist_id": {
+                        "type": "string",
+                        "description": "Spotify playlist ID"
+                    }
+                },
+                "required": ["playlist_id"]
+            }
         }
     ]
 }
@@ -191,8 +205,9 @@ async def handle_mcp_request(request: Request):
         mcp_request = MCPRequest(**body)
         
         # Verify authentication for commands that require it
-        if mcp_request.method in ["play_music", "pause_music", "skip_next", "skip_previous", 
-                                 "set_volume", "get_current_playing", "get_playback_state"]:
+        if mcp_request.method in ["play_music", "pause_music", "skip_next", "skip_previous",
+                                 "set_volume", "get_current_playing", "get_playback_state",
+                                 "clear_playlist"]:
             if not controller.is_authenticated():
                 return JSONResponse(
                     status_code=401,
@@ -277,7 +292,13 @@ async def process_mcp_command(request: MCPRequest) -> Dict[str, Any]:
     
     elif method == "get_playlists":
         return controller.get_playlists()
-    
+
+    elif method == "clear_playlist":
+        playlist_id = params.get("playlist_id")
+        if not playlist_id:
+            raise ValueError("playlist_id is required")
+        return controller.clear_playlist(playlist_id)
+
     else:
         raise ValueError(f"Method '{method}' not supported")
 

--- a/src/mcp_stdio_server.py
+++ b/src/mcp_stdio_server.py
@@ -173,6 +173,17 @@ class MCPServer:
                         },
                         "required": ["playlist_id", "new_name"]
                     }
+                },
+                {
+                    "name": "clear_playlist",
+                    "description": "Remove all tracks from a Spotify playlist",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "playlist_id": {"type": "string", "description": "Spotify playlist ID"}
+                        },
+                        "required": ["playlist_id"]
+                    }
                 }
             ]
         }
@@ -252,7 +263,7 @@ class MCPServer:
                 # Check authentication for commands that require it
                 if tool_name in ["play_music", "pause_music", "skip_next", "skip_previous",
                                  "set_volume", "get_current_playing", "get_playback_state", "get_playlist_tracks",
-                                 "rename_playlist"]:
+                                 "rename_playlist", "clear_playlist"]:
 
                     logger.info(f"Checking authentication for {tool_name}")
                     if not self.controller.is_authenticated():
@@ -466,6 +477,20 @@ class MCPServer:
                 else:
                     return result
 
+
+            elif tool_name == "clear_playlist":
+                playlist_id = arguments.get("playlist_id")
+                if not playlist_id:
+                    raise ValueError("playlist_id is required")
+
+                result = self.controller.clear_playlist(playlist_id)
+                if isinstance(result, dict):
+                    if result.get('success'):
+                        return f"{result.get('message', 'Playlist cleared successfully')}"
+                    else:
+                        return f"Error clearing playlist: {result.get('message', 'Unknown error')}"
+                else:
+                    return result
 
             else:
                 raise ValueError(f"Tool '{tool_name}' not supported")

--- a/src/spotify_client.py
+++ b/src/spotify_client.py
@@ -248,3 +248,14 @@ class SpotifyClient:
         )
         sys.stderr.write(f"DEBUG: Response renaming playlist by id {playlist_id}: {result}\n")
         return result is not None
+
+    def clear_playlist(self, playlist_id: str) -> bool:
+        """Remove all tracks from a playlist"""
+        logger.info(f"DEBUG: spotify_client -- Clearing playlist with id {playlist_id}")
+        result = self._make_request(
+            'PUT',
+            f'/playlists/{playlist_id}/tracks',
+            json={"uris": []}
+        )
+        sys.stderr.write(f"DEBUG: Response clearing playlist by id {playlist_id}: {result}\n")
+        return result is not None

--- a/src/spotify_controller.py
+++ b/src/spotify_controller.py
@@ -268,6 +268,19 @@ class SpotifyController:
         except Exception as e:
             return {"success": False, "message": f"Error: {str(e)}"}
 
+    def clear_playlist(self, playlist_id: str) -> Dict[str, Any]:
+        """Remove all tracks from a playlist"""
+        logger.info(f"DEBUG: spotify_controller : Clearing playlist with id {playlist_id}")
+        try:
+            if not self._validate_spotify_id(playlist_id):
+                return {'success': False, 'message': 'Invalid playlist ID. It must be a valid Spotify ID.'}
+            result = self.client.clear_playlist(playlist_id)
+            if result:
+                return {"success": True, "message": "Playlist cleared successfully"}
+            return {"success": False, "message": "Could not clear the playlist"}
+        except Exception as e:
+            return {"success": False, "message": f"Error: {str(e)}"}
+
 
     def _validate_spotify_id(self, id_string: str) -> bool:
         """Validates if the string it's a valid Spotify ID"""

--- a/test_clear_playlist.py
+++ b/test_clear_playlist.py
@@ -1,0 +1,27 @@
+import pytest
+from unittest.mock import patch
+
+from src.spotify_client import SpotifyClient
+from src.spotify_controller import SpotifyController
+
+
+def test_spotify_client_clear_playlist():
+    client = SpotifyClient()
+    with patch.object(client, '_make_request', return_value={}) as mock_request:
+        assert client.clear_playlist('playlist123') is True
+        mock_request.assert_called_once_with('PUT', '/playlists/playlist123/tracks', json={'uris': []})
+
+
+def test_spotify_controller_clear_playlist():
+    controller = SpotifyController()
+    with patch.object(controller.client, 'clear_playlist', return_value=True) as mock_clear:
+        result = controller.clear_playlist('playlist123')
+        assert result['success'] is True
+        assert 'cleared' in result['message'].lower()
+        mock_clear.assert_called_once_with('playlist123')
+
+
+def test_spotify_controller_clear_playlist_invalid():
+    controller = SpotifyController()
+    result = controller.clear_playlist('bad id!')
+    assert result['success'] is False


### PR DESCRIPTION
## Summary
- add client and controller support for clearing all tracks from a playlist
- expose new `clear_playlist` MCP tool over HTTP and stdio servers with auth checks
- document playlist clearing in README
- test playlist clearing behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68971727c43c832c9c3359ba8b82c2a6