### PR TITLE
feat: support clearing playlists via stdio server

### DIFF
--- a/src/mcp_stdio_server.py
+++ b/src/mcp_stdio_server.py
@@ -175,6 +175,17 @@ class MCPServer:
                     }
                 },
                 {
+                    "name": "clear_playlist",
+                    "description": "Remove all tracks from a Spotify playlist",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "playlist_id": {"type": "string", "description": "Spotify playlist ID"}
+                        },
+                        "required": ["playlist_id"]
+                    }
+                },
+                {
                     "name": "create_playlist",
                     "description": "Create a new Spotify playlist with the given name",
                     "inputSchema": {
@@ -280,7 +291,7 @@ class MCPServer:
                 # Check authentication for commands that require it
                 if tool_name in ["play_music", "pause_music", "skip_next", "skip_previous",
                                  "set_volume", "get_current_playing", "get_playback_state", "get_playlist_tracks",
-                                 "rename_playlist", "create_playlist", "add_tracks_to_playlist"]:
+                                 "rename_playlist", "clear_playlist", "create_playlist", "add_tracks_to_playlist"]:
 
                     logger.info(f"Checking authentication for {tool_name}")
                     if not self.controller.is_authenticated():
@@ -477,6 +488,20 @@ class MCPServer:
                         return f"{result.get('message', 'Playlist renamed successfully')}"
                     else:
                         return f"Error renaming playlist: {result.get('message', 'Unknown error')}"
+                else:
+                    return result
+
+            elif tool_name == "clear_playlist":
+                playlist_id = arguments.get("playlist_id")
+                if not playlist_id:
+                    raise ValueError("playlist_id is required")
+
+                result = self.controller.clear_playlist(playlist_id)
+                if isinstance(result, dict):
+                    if result.get('success'):
+                        return f"{result.get('message', 'Playlist cleared successfully')}"
+                    else:
+                        return f"Error clearing playlist: {result.get('message', 'Unknown error')}"
                 else:
                     return result
 

--- a/test_clear_playlist.py
+++ b/test_clear_playlist.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from src.spotify_client import SpotifyClient
 from src.spotify_controller import SpotifyController
+from src.mcp_stdio_server import MCPServer
 
 
 def test_spotify_client_clear_playlist():
@@ -25,3 +26,16 @@ def test_spotify_controller_clear_playlist_invalid():
     controller = SpotifyController()
     result = controller.clear_playlist('bad id!')
     assert result['success'] is False
+
+
+def test_mcp_server_clear_playlist():
+    server = MCPServer()
+    assert any(tool["name"] == "clear_playlist" for tool in server.manifest["tools"])
+    with patch.object(
+        server.controller,
+        "clear_playlist",
+        return_value={"success": True, "message": "Playlist cleared successfully"},
+    ) as mock_clear:
+        result = server.execute_tool("clear_playlist", {"playlist_id": "playlist123"})
+        assert "cleared" in result.lower()
+        mock_clear.assert_called_once_with("playlist123")


### PR DESCRIPTION
## Summary
- expose `clear_playlist` tool in stdio server manifest
- route `clear_playlist` calls to controller with auth gating
- test clear playlist handling on server

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898d14cfc64832c992f74a9d9547de3