### PR TITLE
feat: centralize tool dispatch in MCP server

### DIFF
--- a/test_clear_playlist.py
+++ b/test_clear_playlist.py
@@ -36,6 +36,7 @@ def test_mcp_server_clear_playlist():
         "clear_playlist",
         return_value={"success": True, "message": "Playlist cleared successfully"},
     ) as mock_clear:
+        server.TOOL_HANDLERS["clear_playlist"] = server.controller.clear_playlist
         result = server.execute_tool("clear_playlist", {"playlist_id": "playlist123"})
         assert "cleared" in result.lower()
-        mock_clear.assert_called_once_with("playlist123")
+        mock_clear.assert_called_once_with(playlist_id="playlist123")

--- a/test_execute_tool_dispatch.py
+++ b/test_execute_tool_dispatch.py
@@ -1,0 +1,31 @@
+import pytest
+from src.mcp_stdio_server import MCPServer
+
+class DummyController:
+    def pause_music(self):
+        return {"success": True, "message": "Playback paused"}
+
+    def set_volume(self, volume_percent):
+        return {"success": True, "message": f"Volume set to {volume_percent}%"}
+
+
+def test_dispatch_calls_correct_handler():
+    server = MCPServer()
+    server.controller = DummyController()
+    server.TOOL_HANDLERS["pause_music"] = server.controller.pause_music
+    result = server.execute_tool("pause_music", {})
+    assert result == "Playback paused"
+
+
+def test_validation_errors_are_raised():
+    server = MCPServer()
+    server.controller = DummyController()
+    server.TOOL_HANDLERS["set_volume"] = server.controller.set_volume
+    result = server.execute_tool("set_volume", {})
+    assert "volume_percent is required" in result
+
+
+def test_unknown_tool():
+    server = MCPServer()
+    result = server.execute_tool("unknown_tool", {})
+    assert "Tool 'unknown_tool' not supported" in result


### PR DESCRIPTION
## Summary
- add TOOL_HANDLERS to map tool names to SpotifyController methods
- refactor execute_tool to use dynamic dispatch with validators and formatters
- cover new dispatch mechanism with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898d755ca30832c92b59f2a05542483