### PR TITLE
docs: document start_server helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ mcp-spotify-player/
    - Direct communication with Claude
 
 ### Run in development mode
+#### Using the helper script
+
+```bash
+python start_server.py
+```
+
+`start_server.py` checks that dependencies are installed, the `.env` file is properly configured and that port `8000` is available before launching the server. It prints the main endpoints and offers tips to fix common errors.
+
+#### Direct commands
 
 ```bash
 # HTTP server (for testing)


### PR DESCRIPTION
## Summary
- document `start_server.py` as a development helper script
- explain how it validates env/port and lists endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689989b041bc832c83c5cf5dc2c1c107