### PR TITLE
feat: expose available devices

### DIFF
--- a/CLAUDE_INTEGRATION.md
+++ b/CLAUDE_INTEGRATION.md
@@ -95,6 +95,7 @@ Once integrated, Claude can use these commands:
 - `set_volume` - Change volume
 - `get_current_playing` - Current track
 - `get_playback_state` - Full playback state
+- `get_devices` - List available devices
 - `search_music` - Search music
 - `get_playlists` - List playlists
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,7 @@ Create an MCP server that allows Claude to control Spotify using natural command
 - `set_volume` - Change volume
 - `get_current_playing` - Current track
 - `get_playback_state` - Full playback state
+- `get_devices` - List available devices
 - `search_music` - Search music
 - `get_playlists` - List playlists
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Control your Spotify music from Claude using the MCP (Model Context Protocol).
 
 - **Playback control**: Play, pause, skip songs
 - **Playback status**: Check current song and device status
+- **Device information**: List available playback devices
 - **Volume control**: Adjust volume from 0 to 100%
 - **Music search**: Search for songs, artists, and albums
 - **Playlist management**: List, create, rename, clear, and add tracks to your playlists
@@ -84,6 +85,7 @@ Once authenticated, you can use these commands:
 - `set_volume` — "Set volume to 50%"
 - `get_current_playing` — "What's playing?"
 - `get_playback_state` — "What's the playback state?"
+- `get_devices` — "List my available devices"
 - `search_music` — "Search for songs by Queen"
 - `get_playlists` — "List my playlists"
 - `get_playlist_tracks` — "Show tracks in playlist 'Road Trip'"

--- a/src/client_playback.py
+++ b/src/client_playback.py
@@ -52,6 +52,10 @@ class SpotifyPlaybackClient:
         """Gets the current playback status"""
         return self.requester._make_request('GET', '/me/player')
 
+    def get_devices(self) -> Optional[Dict[str, Any]]:
+        """Get available playback devices"""
+        return self.requester._make_request('GET', '/me/player/devices')
+
     def _search(self, query: str, type_: str, limit: int = 10) -> Optional[Dict[str, Any]]:
         """Internal helper to perform a search request against Spotify."""
         params = {

--- a/src/mcp_manifest.py
+++ b/src/mcp_manifest.py
@@ -94,6 +94,14 @@ MANIFEST = {
             }
         },
         {
+            "name": "get_devices",
+            "description": "Retrieve available Spotify devices",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
+            }
+        },
+        {
             "name": "search_music",
             "description": "Search for music on Spotify by track, artist, or album",
             "inputSchema": {

--- a/src/mcp_stdio_server.py
+++ b/src/mcp_stdio_server.py
@@ -34,6 +34,7 @@ class MCPServer:
             "set_volume": self.controller.playback.set_volume,
             "get_current_playing": self.controller.playback.get_current_playing,
             "get_playback_state": self.controller.playback.get_playback_state,
+            "get_devices": self.controller.playback.get_devices,
             "search_music": self.controller.playback.search_music,
             "get_playlists": self.controller.playlists.get_playlists,
             "get_playlist_tracks": self.controller.playlists.get_playlist_tracks,
@@ -57,6 +58,7 @@ class MCPServer:
         self.RESULT_FORMATTERS = {
             "get_current_playing": self._format_get_current_playing,
             "get_playback_state": self._format_get_playback_state,
+            "get_devices": self._format_json_result,
             "search_music": self._format_json_result,
             "get_playlists": self._format_json_result,
             "get_playlist_tracks": self._format_json_result,
@@ -137,7 +139,7 @@ class MCPServer:
 
                 # Check authentication for commands that require it
                 if tool_name in ["play_music", "pause_music", "skip_next", "skip_previous",
-                                 "set_volume", "get_current_playing", "get_playback_state", "get_playlist_tracks",
+                                 "set_volume", "get_current_playing", "get_playback_state", "get_devices", "get_playlist_tracks",
                                  "rename_playlist", "clear_playlist", "create_playlist", "add_tracks_to_playlist"]:
 
                     logger.info(f"Checking authentication for {tool_name}")

--- a/src/playback_controller.py
+++ b/src/playback_controller.py
@@ -158,6 +158,26 @@ class PlaybackController:
         except Exception as e:
             return {"success": False, "message": f"Error: {str(e)}"}
 
+    def get_devices(self) -> Dict[str, Any]:
+        """Get available playback devices"""
+        try:
+            devices_data = self.playback_client.get_devices()
+            if devices_data and devices_data.get('devices'):
+                devices = [
+                    {
+                        "id": d.get('id'),
+                        "name": d.get('name'),
+                        "type": d.get('type'),
+                        "is_active": d.get('is_active', False),
+                        "volume_percent": d.get('volume_percent'),
+                    }
+                    for d in devices_data['devices']
+                ]
+                return {"success": True, "devices": devices}
+            return {"success": False, "message": "No devices available"}
+        except Exception as e:
+            return {"success": False, "message": f"Error: {str(e)}"}
+
     def search_music(self, query: str, search_type: str = "track", limit: int = 10) -> Dict[str, Any]:
         """Search for music on Spotify"""
         try:

--- a/tests/test_get_devices_controller.py
+++ b/tests/test_get_devices_controller.py
@@ -1,0 +1,33 @@
+from src.playback_controller import PlaybackController
+
+
+def test_get_devices_controller():
+    class DummyPlayback:
+        def get_devices(self):
+            return {
+                "devices": [
+                    {
+                        "id": "1",
+                        "name": "Computer",
+                        "type": "Computer",
+                        "is_active": True,
+                        "volume_percent": 50,
+                    },
+                    {
+                        "id": "2",
+                        "name": "Speaker",
+                        "type": "Speaker",
+                        "is_active": False,
+                        "volume_percent": 100,
+                    },
+                ]
+            }
+
+    dummy_client = type("Dummy", (), {"playback": DummyPlayback(), "playlists": None})()
+    controller = PlaybackController(dummy_client)
+
+    result = controller.get_devices()
+    assert result["success"] is True
+    assert len(result["devices"]) == 2
+    assert result["devices"][0]["name"] == "Computer"
+    assert result["devices"][1]["is_active"] is False

--- a/tests/test_get_devices_manifest.py
+++ b/tests/test_get_devices_manifest.py
@@ -1,0 +1,9 @@
+from src.mcp_stdio_server import MCPServer
+
+
+def test_get_devices_in_stdio_manifest():
+    server = MCPServer()
+    tool_names = [tool["name"] for tool in server.manifest["tools"]]
+    assert "get_devices" in tool_names
+
+


### PR DESCRIPTION
## Summary
- add client and controller methods to retrieve available Spotify devices
- expose `get_devices` tool in MCP manifests and servers
- document and test available device retrieval

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689990703654832ca95bfc2b7056e141