### PR TITLE
feat: support configurable tokens path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ Control your Spotify music from Claude using the MCP (Model Context Protocol).
    SPOTIFY_CLIENT_ID=your_client_id_here
    SPOTIFY_CLIENT_SECRET=your_client_secret_here
    SPOTIFY_REDIRECT_URI=http://127.0.0.1:8000/auth/callback
+   # Optional: custom path to store OAuth tokens
+   # Defaults to ~/.config/mcp_spotify_player/tokens.json
+   MCP_SPOTIFY_TOKENS_PATH=/path/to/tokens.json
    ```
+
+   If `MCP_SPOTIFY_TOKENS_PATH` is not set, tokens will be stored in
+   `~/.config/mcp_spotify_player/tokens.json` by default.
 
 ## 🔐 Spotify Configuration
 

--- a/src/client_auth.py
+++ b/src/client_auth.py
@@ -20,9 +20,14 @@ class SpotifyAuthClient:
         self.token_expires_at = 0
         self.config = Config()
 
-        # Get project dir path
-        self.project_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        self.tokens_file = os.path.join(self.project_dir, 'tokens.json')
+        # Determine tokens storage path
+        tokens_path = os.getenv("MCP_SPOTIFY_TOKENS_PATH")
+        if tokens_path:
+            self.tokens_file = os.path.expanduser(tokens_path)
+        else:
+            self.tokens_file = os.path.expanduser(
+                os.path.join("~", ".config", "mcp_spotify_player", "tokens.json")
+            )
 
     def get_auth_url(self) -> str:
         """Generate Spotify Authorization URL"""
@@ -83,6 +88,7 @@ class SpotifyAuthClient:
             'refresh_token': self.refresh_token,
             'expires_at': self.token_expires_at
         }
+        os.makedirs(os.path.dirname(self.tokens_file), exist_ok=True)
         with open(self.tokens_file, 'w') as f:
             json.dump(token_data, f)
 


### PR DESCRIPTION
## Summary
- allow overriding OAuth token path via `MCP_SPOTIFY_TOKENS_PATH`
- default tokens saved under `~/.config/mcp_spotify_player/tokens.json`
- document new environment variable and default path

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aee3252b8832cb0e01589c6619000