### PR TITLE
Wire up token loading and validation

### DIFF
--- a/src/mcp_spotify/errors.py
+++ b/src/mcp_spotify/errors.py
@@ -1,5 +1,17 @@
 from __future__ import annotations
 
 
-class InvalidTokenFileError(Exception):
+class McpUserError(Exception):
+    """Base error surfaced directly to MCP clients."""
+
+
+class InvalidTokenFileError(McpUserError):
     """Raised when the token file is missing or malformed."""
+
+
+class NotAuthenticatedError(McpUserError):
+    """Raised when no Spotify authentication is available."""
+
+
+class TokenExpiredError(McpUserError):
+    """Raised when the Spotify access token has expired."""

--- a/src/mcp_spotify_player/client_auth.py
+++ b/src/mcp_spotify_player/client_auth.py
@@ -3,15 +3,42 @@ import logging
 import os
 import sys
 import time
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 import requests
 
-from mcp_spotify_player.config import Config
+from mcp_spotify.auth.tokens import Tokens, load_tokens
+from mcp_spotify_player.config import Config, resolve_tokens_path
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def try_load_tokens() -> Optional[Tokens]:
+    """Attempt to load tokens from disk.
+
+    Returns ``None`` if the token file does not exist. If the file exists but
+    is invalid an ``InvalidTokenFileError`` is raised.
+    """
+
+    path: Path = resolve_tokens_path()
+    if not path.exists():
+        return None
+    return load_tokens(path)
+
+
+def is_token_expired(tokens: Tokens, now: int | None = None) -> bool:
+    """Return ``True`` if ``tokens`` are expired.
+
+    A safety margin of 60 seconds is applied.
+    """
+
+    if now is None:
+        now = int(time.time())
+    return now >= tokens.expires_at - 60
+
 
 class SpotifyAuthClient:
     """Handles Spotify authentication and token management."""
@@ -35,30 +62,30 @@ class SpotifyAuthClient:
     def get_auth_url(self) -> str:
         """Generate Spotify Authorization URL"""
         params = {
-            'client_id': self.config.SPOTIFY_CLIENT_ID,
-            'response_type': 'code',
-            'redirect_uri': self.config.SPOTIFY_REDIRECT_URI,
-            'scope': ' '.join(self.config.SPOTIFY_SCOPES),
-            'show_dialog': 'true'
+            "client_id": self.config.SPOTIFY_CLIENT_ID,
+            "response_type": "code",
+            "redirect_uri": self.config.SPOTIFY_REDIRECT_URI,
+            "scope": " ".join(self.config.SPOTIFY_SCOPES),
+            "show_dialog": "true",
         }
-        query_string = '&'.join([f"{k}={v}" for k, v in params.items()])
+        query_string = "&".join([f"{k}={v}" for k, v in params.items()])
         return f"{self.config.SPOTIFY_AUTH_URL}?{query_string}"
 
     def exchange_code_for_tokens(self, auth_code: str) -> bool:
         """Exchange the authorization code for tokens"""
         data = {
-            'grant_type': 'authorization_code',
-            'code': auth_code,
-            'redirect_uri': self.config.SPOTIFY_REDIRECT_URI,
-            'client_id': self.config.SPOTIFY_CLIENT_ID,
-            'client_secret': self.config.SPOTIFY_CLIENT_SECRET
+            "grant_type": "authorization_code",
+            "code": auth_code,
+            "redirect_uri": self.config.SPOTIFY_REDIRECT_URI,
+            "client_id": self.config.SPOTIFY_CLIENT_ID,
+            "client_secret": self.config.SPOTIFY_CLIENT_SECRET,
         }
         response = requests.post(self.config.SPOTIFY_TOKEN_URL, data=data)
         if response.status_code == 200:
             token_data = response.json()
-            self.access_token = token_data['access_token']
-            self.refresh_token = token_data.get('refresh_token')
-            self.token_expires_at = time.time() + token_data['expires_in']
+            self.access_token = token_data["access_token"]
+            self.refresh_token = token_data.get("refresh_token")
+            self.token_expires_at = time.time() + token_data["expires_in"]
             self._save_tokens()
             return True
         return False
@@ -68,18 +95,18 @@ class SpotifyAuthClient:
         if not self.refresh_token:
             return False
         data = {
-            'grant_type': 'refresh_token',
-            'refresh_token': self.refresh_token,
-            'client_id': self.config.SPOTIFY_CLIENT_ID,
-            'client_secret': self.config.SPOTIFY_CLIENT_SECRET
+            "grant_type": "refresh_token",
+            "refresh_token": self.refresh_token,
+            "client_id": self.config.SPOTIFY_CLIENT_ID,
+            "client_secret": self.config.SPOTIFY_CLIENT_SECRET,
         }
         response = requests.post(self.config.SPOTIFY_TOKEN_URL, data=data)
         if response.status_code == 200:
             token_data = response.json()
-            self.access_token = token_data['access_token']
-            self.token_expires_at = time.time() + token_data['expires_in']
-            if 'refresh_token' in token_data:
-                self.refresh_token = token_data['refresh_token']
+            self.access_token = token_data["access_token"]
+            self.token_expires_at = time.time() + token_data["expires_in"]
+            if "refresh_token" in token_data:
+                self.refresh_token = token_data["refresh_token"]
             self._save_tokens()
             return True
         return False
@@ -87,12 +114,12 @@ class SpotifyAuthClient:
     def _save_tokens(self):
         """Save the tokens to a local file"""
         token_data = {
-            'access_token': self.access_token,
-            'refresh_token': self.refresh_token,
-            'expires_at': self.token_expires_at
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "expires_at": self.token_expires_at,
         }
         os.makedirs(os.path.dirname(self.tokens_file), exist_ok=True)
-        with open(self.tokens_file, 'w') as f:
+        with open(self.tokens_file, "w") as f:
             json.dump(token_data, f)
 
     def _load_tokens(self) -> bool:
@@ -100,9 +127,9 @@ class SpotifyAuthClient:
         try:
             with open(self.tokens_file) as f:
                 token_data = json.load(f)
-            self.access_token = token_data['access_token']
-            self.refresh_token = token_data['refresh_token']
-            self.token_expires_at = token_data['expires_at']
+            self.access_token = token_data["access_token"]
+            self.refresh_token = token_data["refresh_token"]
+            self.token_expires_at = token_data["expires_at"]
             return True
         except FileNotFoundError:
             return False
@@ -123,28 +150,29 @@ class SpotifyAuthClient:
         if not token:
             sys.stderr.write(f"INFO: Could not obtain valid token for {endpoint}\n")
             return None
-        headers = {
-            'Authorization': f'Bearer {token}',
-            'Content-Type': 'application/json'
-        }
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         url = f"{self.config.SPOTIFY_API_BASE}{endpoint}"
         params_str = ""
-        if 'params' in kwargs:
+        if "params" in kwargs:
             params_str = f" with params : {kwargs['params']}"
         sys.stderr.write(f"DEBUG: Making request {method} to {endpoint}{params_str}\n")
         response = requests.request(method, url, headers=headers, **kwargs)
         sys.stderr.write(f"DEBUG: Response {response.status_code} for {endpoint}\n")
         if response.status_code in [200, 201, 204]:
-            if method == 'PUT' and endpoint == '/me/player/repeat':
+            if method == "PUT" and endpoint == "/me/player/repeat":
                 return True
             try:
                 return response.json() if response.text else True
             except ValueError:
                 return True
         else:
-            sys.stderr.write(f"DEBUG: Error {response.status_code} for {endpoint}: {response.text}\n")
+            sys.stderr.write(
+                f"DEBUG: Error {response.status_code} for {endpoint}: {response.text}\n"
+            )
             try:
-                sys.stderr.write(f"DEBUG: Trying to parse JSON response for  {endpoint}\n. Response: {response.json()}\n")
+                sys.stderr.write(
+                    f"DEBUG: Trying to parse JSON response for  {endpoint}\n. Response: {response.json()}\n"
+                )
                 return response.json()
             except Exception:
                 sys.stderr.write(f"DEBUG: Error for {endpoint}: {response}\n")

--- a/src/mcp_spotify_player/config.py
+++ b/src/mcp_spotify_player/config.py
@@ -1,25 +1,46 @@
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
 # Load environment variables
 load_dotenv()
 
+
+def resolve_tokens_path() -> Path:
+    """Return the path where OAuth tokens are stored.
+
+    If the ``MCP_SPOTIFY_TOKENS_PATH`` environment variable is set it is
+    expanded and returned. Otherwise the default path is
+    ``~/.config/mcp_spotify_player/tokens.json``. The parent directory is
+    created if it does not already exist.
+    """
+
+    env_path = os.getenv("MCP_SPOTIFY_TOKENS_PATH")
+    if env_path:
+        path = Path(env_path).expanduser().resolve()
+    else:
+        path = Path("~/.config/mcp_spotify_player/tokens.json").expanduser()
+    # Ensure the parent directory exists but do not create the file itself
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 class Config:
     # Spotify API Configuration
     SPOTIFY_CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
     SPOTIFY_CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
     SPOTIFY_REDIRECT_URI = os.getenv("SPOTIFY_REDIRECT_URI", "http://localhost:8000/auth/callback")
-    
+
     # Server Configuration
     PORT = int(os.getenv("PORT", 8000))
     HOST = os.getenv("HOST", "127.0.0.1")
     DEBUG = os.getenv("DEBUG", "True").lower() == "true"
-    
+
     # MCP Configuration
     MCP_SERVER_NAME = os.getenv("MCP_SERVER_NAME", "spotify-player")
     MCP_SERVER_VERSION = os.getenv("MCP_SERVER_VERSION", "1.0.0")
-    
+
     # Spotify API URLs
     SPOTIFY_AUTH_URL = "https://accounts.spotify.com/authorize"
     SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
@@ -27,15 +48,15 @@ class Config:
 
     # Scopes need for Spotify API access
     SPOTIFY_SCOPES = [
-        "user-read-playback-state",        # Read current playback state
-        "user-modify-playback-state",      # Control playback (play, pause, skip)
-        "user-read-currently-playing",     # Read what song is currently playing
-        "user-read-recently-played",       # View recently played songs
-        "user-read-playback-position",     # Read current position in the song
-        "user-top-read",                   # Read user's favorite songs/artists
-        "playlist-read-private",           # Read user's private playlists
-        "playlist-read-collaborative",     # Read collaborative playlists
-        "playlist-modify-private",         # Modify private playlists
-        "user-library-read",               # Read user's library (likes)
-        "user-library-modify"              # Modify user's library (like/unlike)
+        "user-read-playback-state",  # Read current playback state
+        "user-modify-playback-state",  # Control playback (play, pause, skip)
+        "user-read-currently-playing",  # Read what song is currently playing
+        "user-read-recently-played",  # View recently played songs
+        "user-read-playback-position",  # Read current position in the song
+        "user-top-read",  # Read user's favorite songs/artists
+        "playlist-read-private",  # Read user's private playlists
+        "playlist-read-collaborative",  # Read collaborative playlists
+        "playlist-modify-private",  # Modify private playlists
+        "user-library-read",  # Read user's library (likes)
+        "user-library-modify",  # Modify user's library (like/unlike)
     ]

--- a/src/mcp_spotify_player/spotify_client.py
+++ b/src/mcp_spotify_player/spotify_client.py
@@ -1,20 +1,56 @@
-from mcp_spotify_player.client_auth import SpotifyAuthClient
+from typing import Callable, Optional
+
+import requests
+
+from mcp_spotify.auth.tokens import Tokens
+from mcp_spotify.errors import NotAuthenticatedError, TokenExpiredError
+from mcp_spotify_player.client_auth import is_token_expired
 from mcp_spotify_player.client_playback import SpotifyPlaybackClient
 from mcp_spotify_player.client_playlists import SpotifyPlaylistsClient
+from mcp_spotify_player.config import Config
+
+
+TokensProvider = Callable[[], Optional[Tokens]]
 
 
 class SpotifyClient:
-    """Unified interface that composes auth, playback and playlist clients."""
+    """Unified interface to the Spotify Web API."""
 
-    def __init__(self):
-        self.auth = SpotifyAuthClient()
-        # Expose _make_request so tests can patch it on the main client
-        self._make_request = self.auth._make_request
+    def __init__(self, tokens_provider: TokensProvider | None = None):
+        self.tokens_provider: TokensProvider = tokens_provider or (lambda: None)
+        self.config = Config()
         self.playback = SpotifyPlaybackClient(self)
         self.playlists = SpotifyPlaylistsClient(self)
 
+    def _make_request(self, method: str, endpoint: str, **kwargs):
+        tokens = self.tokens_provider()
+        if tokens is None:
+            raise NotAuthenticatedError("Not authenticated with Spotify. Run /auth.")
+        if is_token_expired(tokens):
+            raise TokenExpiredError("Access token expired. Run /auth or refresh tokens.")
+
+        headers = {
+            "Authorization": f"Bearer {tokens.access_token}",
+            "Content-Type": "application/json",
+        }
+        url = f"{self.config.SPOTIFY_API_BASE}{endpoint}"
+        response = requests.request(method, url, headers=headers, **kwargs)
+
+        if response.status_code in [200, 201, 204]:
+            if method == "PUT" and endpoint == "/me/player/repeat":
+                return True
+            try:
+                return response.json() if response.text else True
+            except ValueError:
+                return True
+
+        try:
+            return response.json()
+        except Exception:
+            return {"error": response.text}
+
     def __getattr__(self, name):
-        for client in (self.playback, self.playlists, self.auth):
+        for client in (self.playback, self.playlists):
             if hasattr(client, name):
                 return getattr(client, name)
         raise AttributeError(f"{self.__class__.__name__} object has no attribute {name}")

--- a/tests/auth/test_token_wiring.py
+++ b/tests/auth/test_token_wiring.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from mcp_spotify.auth.tokens import Tokens
+from mcp_spotify.errors import (
+    InvalidTokenFileError,
+    NotAuthenticatedError,
+    TokenExpiredError,
+)
+from mcp_spotify_player.client_auth import try_load_tokens
+from mcp_spotify_player.spotify_client import SpotifyClient
+
+
+def test_no_tokens_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(tmp_path / "tokens.json"))
+    assert try_load_tokens() is None
+    client = SpotifyClient(lambda: None)
+    with pytest.raises(NotAuthenticatedError):
+        client.playback.get_playback_state()
+
+
+def test_invalid_token_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "tokens.json"
+    path.write_text("{")
+    monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(path))
+    with pytest.raises(InvalidTokenFileError):
+        try_load_tokens()
+
+    def provider() -> Tokens | None:
+        raise InvalidTokenFileError(
+            "Token file is invalid. Fix tokens.json or run /auth to regenerate it."
+        )
+
+    client = SpotifyClient(provider)
+    with pytest.raises(InvalidTokenFileError):
+        client.playback.get_playback_state()
+
+
+def test_expired_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "tokens.json"
+    data = {"access_token": "a", "refresh_token": "r", "expires_at": 0}
+    path.write_text(json.dumps(data))
+    monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(path))
+    tokens = try_load_tokens()
+    assert tokens is not None
+    client = SpotifyClient(lambda: tokens)
+    with pytest.raises(TokenExpiredError):
+        client.playback.get_playback_state()

--- a/tests/test_clear_playlist.py
+++ b/tests/test_clear_playlist.py
@@ -8,24 +8,26 @@ from mcp_spotify_player.mcp_stdio_server import MCPServer
 
 def test_spotify_client_clear_playlist():
     client = SpotifyClient()
-    with patch.object(client, '_make_request', return_value={}) as mock_request:
-        assert client.clear_playlist('playlist123') is True
-        mock_request.assert_called_once_with('PUT', '/playlists/playlist123/tracks', json={'uris': []})
+    with patch.object(client, "_make_request", return_value={}) as mock_request:
+        assert client.clear_playlist("playlist123") is True
+        mock_request.assert_called_once_with(
+            "PUT", "/playlists/playlist123/tracks", json={"uris": []}
+        )
 
 
 def test_spotify_controller_clear_playlist():
-    controller = SpotifyController()
-    with patch.object(controller.client, 'clear_playlist', return_value=True) as mock_clear:
-        result = controller.clear_playlist('playlist123')
-        assert result['success'] is True
-        assert 'cleared' in result['message'].lower()
-        mock_clear.assert_called_once_with('playlist123')
+    controller = SpotifyController(lambda: None)
+    with patch.object(controller.client, "clear_playlist", return_value=True) as mock_clear:
+        result = controller.clear_playlist("playlist123")
+        assert result["success"] is True
+        assert "cleared" in result["message"].lower()
+        mock_clear.assert_called_once_with("playlist123")
 
 
 def test_spotify_controller_clear_playlist_invalid():
-    controller = SpotifyController()
-    result = controller.clear_playlist('bad id!')
-    assert result['success'] is False
+    controller = SpotifyController(lambda: None)
+    result = controller.clear_playlist("bad id!")
+    assert result["success"] is False
 
 
 def test_mcp_server_clear_playlist():


### PR DESCRIPTION
## Summary
- add configurable token path resolver
- validate tokens on startup and per request
- surface user-facing auth errors and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b19d03f10832ca6e7d697f70605d4