### PR TITLE
feat: auto refresh Spotify tokens

### DIFF
--- a/src/mcp_spotify/auth/tokens.py
+++ b/src/mcp_spotify/auth/tokens.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from mcp_spotify.errors import InvalidTokenFileError
+import requests
+import time
+
+from mcp_spotify.errors import InvalidTokenFileError, RefreshNotPossibleError
+from mcp_spotify_player.config import Config, resolve_tokens_path
 
 
 @dataclass(slots=True)
@@ -13,6 +17,43 @@ class Tokens:
     access_token: str
     refresh_token: str
     expires_at: int
+
+
+def needs_refresh(tokens: Tokens, now: int | None = None) -> bool:
+    """Return ``True`` if the access token is close to expiring."""
+
+    if now is None:
+        now = int(time.time())
+    return now >= tokens.expires_at - 60
+
+
+def refresh_tokens(tokens: Tokens, client_id: str, client_secret: str) -> Tokens:
+    """Refresh ``tokens`` using Spotify's OAuth refresh flow and persist them."""
+
+    if not tokens.refresh_token:
+        raise RefreshNotPossibleError("No refresh_token. Please run /auth.")
+
+    data = {
+        "grant_type": "refresh_token",
+        "refresh_token": tokens.refresh_token,
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+    response = requests.post(Config.SPOTIFY_TOKEN_URL, data=data)
+    if response.status_code != 200:
+        raise RefreshNotPossibleError(
+            f"Token refresh failed: {response.status_code}"
+        )
+    payload: dict[str, Any] = response.json()
+    refreshed = Tokens(
+        access_token=payload["access_token"],
+        refresh_token=payload.get("refresh_token", tokens.refresh_token),
+        expires_at=int(time.time()) + int(payload["expires_in"]),
+    )
+
+    path = resolve_tokens_path()
+    path.write_text(json.dumps(asdict(refreshed)))
+    return refreshed
 
 
 def load_tokens(path: Path) -> Tokens:

--- a/src/mcp_spotify/errors.py
+++ b/src/mcp_spotify/errors.py
@@ -15,3 +15,8 @@ class NotAuthenticatedError(McpUserError):
 
 class TokenExpiredError(McpUserError):
     """Raised when the Spotify access token has expired."""
+
+
+class RefreshNotPossibleError(McpUserError):
+    """Raised when refreshing the Spotify access token is not possible."""
+

--- a/src/mcp_spotify_player/client_auth.py
+++ b/src/mcp_spotify_player/client_auth.py
@@ -173,33 +173,3 @@ class SpotifyAuthClient:
             except Exception:
                 sys.stderr.write(f"DEBUG: Error for {endpoint}: {response}\n")
                 return {"error": response.text}
-
-    # def _make_request(self, method: str, endpoint: str, **kwargs) -> Optional[Dict[str, Any]]:
-    #     """Make a request to the Spotify API"""
-    #     token = self._get_valid_token()
-    #     if not token:
-    #         sys.stderr.write(f"INFO: Could not obtain valid token for {endpoint}\n")
-    #         return None
-    #     headers = {
-    #         'Authorization': f'Bearer {token}',
-    #         'Content-Type': 'application/json'
-    #     }
-    #     url = f"{self.config.SPOTIFY_API_BASE}{endpoint}"
-    #     params_str = ""
-    #     if 'params' in kwargs:
-    #         params_str = f" with params : {kwargs['params']}"
-    #     sys.stderr.write(f"DEBUG: Making request {method} to {endpoint}{params_str}\n")
-    #     response = requests.request(method, url, headers=headers, **kwargs)
-    #     sys.stderr.write(f"DEBUG: Response {response.status_code} for {endpoint}\n")
-    #     if response.status_code in [200, 201, 204]:
-    #         result = response.json() if response.content else {}
-    #         sys.stderr.write(f"DEBUG: Successful outcome for{endpoint}: {result}\n")
-    #         return result
-    #     else:
-    #         sys.stderr.write(f"DEBUG: Error {response.status_code} for {endpoint}: {response.text}\n")
-    #         try:
-    #             sys.stderr.write(f"DEBUG: Trying to parse JSON response for  {endpoint}\n. Response: {response.json()}\n")
-    #             return response.json()
-    #         except Exception:
-    #             sys.stderr.write(f"DEBUG: Error for {endpoint}: {response}\n")
-    #             return {"error": response.text}

--- a/src/mcp_spotify_player/client_auth.py
+++ b/src/mcp_spotify_player/client_auth.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from mcp_spotify.auth.tokens import Tokens, load_tokens
+from mcp_spotify.auth.tokens import Tokens, load_tokens, needs_refresh
 from mcp_spotify_player.config import Config, resolve_tokens_path
 
 # Configure logging
@@ -30,14 +30,9 @@ def try_load_tokens() -> Optional[Tokens]:
 
 
 def is_token_expired(tokens: Tokens, now: int | None = None) -> bool:
-    """Return ``True`` if ``tokens`` are expired.
+    """Compatibility wrapper around :func:`needs_refresh`."""
 
-    A safety margin of 60 seconds is applied.
-    """
-
-    if now is None:
-        now = int(time.time())
-    return now >= tokens.expires_at - 60
+    return needs_refresh(tokens, now)
 
 
 class SpotifyAuthClient:

--- a/src/mcp_spotify_player/spotify_client.py
+++ b/src/mcp_spotify_player/spotify_client.py
@@ -2,9 +2,8 @@ from typing import Callable, Optional
 
 import requests
 
-from mcp_spotify.auth.tokens import Tokens
-from mcp_spotify.errors import NotAuthenticatedError, TokenExpiredError
-from mcp_spotify_player.client_auth import is_token_expired
+from mcp_spotify.auth.tokens import Tokens, needs_refresh, refresh_tokens
+from mcp_spotify.errors import NotAuthenticatedError
 from mcp_spotify_player.client_playback import SpotifyPlaybackClient
 from mcp_spotify_player.client_playlists import SpotifyPlaylistsClient
 from mcp_spotify_player.config import Config
@@ -22,12 +21,17 @@ class SpotifyClient:
         self.playback = SpotifyPlaybackClient(self)
         self.playlists = SpotifyPlaylistsClient(self)
 
+    def _refresh(self, tokens: Tokens) -> Tokens:
+        return refresh_tokens(
+            tokens, self.config.SPOTIFY_CLIENT_ID, self.config.SPOTIFY_CLIENT_SECRET
+        )
+
     def _make_request(self, method: str, endpoint: str, **kwargs):
         tokens = self.tokens_provider()
         if tokens is None:
             raise NotAuthenticatedError("Not authenticated with Spotify. Run /auth.")
-        if is_token_expired(tokens):
-            raise TokenExpiredError("Access token expired. Run /auth or refresh tokens.")
+        if needs_refresh(tokens):
+            tokens = self._refresh(tokens)
 
         headers = {
             "Authorization": f"Bearer {tokens.access_token}",
@@ -35,6 +39,11 @@ class SpotifyClient:
         }
         url = f"{self.config.SPOTIFY_API_BASE}{endpoint}"
         response = requests.request(method, url, headers=headers, **kwargs)
+
+        if response.status_code == 401:
+            tokens = self._refresh(tokens)
+            headers["Authorization"] = f"Bearer {tokens.access_token}"
+            response = requests.request(method, url, headers=headers, **kwargs)
 
         if response.status_code in [200, 201, 204]:
             if method == "PUT" and endpoint == "/me/player/repeat":

--- a/tests/auth/test_token_refresh.py
+++ b/tests/auth/test_token_refresh.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+import requests
+
+from mcp_spotify.auth.tokens import Tokens
+from mcp_spotify.errors import RefreshNotPossibleError
+from mcp_spotify_player.spotify_client import SpotifyClient
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, data: dict[str, Any] | None = None):
+        self.status_code = status_code
+        self._data = data or {}
+        self.text = json.dumps(self._data) if self._data else ""
+
+    def json(self) -> dict[str, Any]:
+        return self._data
+
+
+def test_request_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    tokens = Tokens("a", "r", int(time.time()) + 3600)
+    calls: list[str] = []
+
+    def fake_request(method, url, headers=None, **kwargs):
+        calls.append(headers["Authorization"])
+        return DummyResponse(200, {"ok": True})
+
+    def fake_post(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("refresh should not be attempted")
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    client = SpotifyClient(lambda: tokens)
+    assert client.playback.get_playback_state() == {"ok": True}
+    assert calls == ["Bearer a"]
+
+
+def test_request_401_triggers_refresh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    tokens = Tokens("old", "refresh", int(time.time()) + 3600)
+    path = tmp_path / "tokens.json"
+    monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(path))
+
+    responses = [DummyResponse(401), DummyResponse(200, {"ok": True})]
+    headers_seen: list[str] = []
+
+    def fake_request(method, url, headers=None, **kwargs):
+        headers_seen.append(headers["Authorization"])
+        return responses.pop(0)
+
+    def fake_post(url, data):
+        assert data["refresh_token"] == "refresh"
+        return DummyResponse(200, {"access_token": "new", "expires_in": 60})
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    client = SpotifyClient(lambda: tokens)
+    assert client.playback.get_playback_state() == {"ok": True}
+    assert headers_seen == ["Bearer old", "Bearer new"]
+    stored = json.loads(path.read_text())
+    assert stored["access_token"] == "new"
+
+
+def test_missing_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    tokens = Tokens("a", "", 0)
+
+    def fail_request(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("request should not be made")
+
+    monkeypatch.setattr(requests, "request", fail_request)
+    monkeypatch.setattr(requests, "post", fail_request)
+
+    client = SpotifyClient(lambda: tokens)
+    with pytest.raises(RefreshNotPossibleError):
+        client.playback.get_playback_state()
+

--- a/tests/auth/test_token_wiring.py
+++ b/tests/auth/test_token_wiring.py
@@ -1,4 +1,6 @@
 import json
+import json
+import json
 from pathlib import Path
 
 import pytest
@@ -7,7 +9,7 @@ from mcp_spotify.auth.tokens import Tokens
 from mcp_spotify.errors import (
     InvalidTokenFileError,
     NotAuthenticatedError,
-    TokenExpiredError,
+    RefreshNotPossibleError,
 )
 from mcp_spotify_player.client_auth import try_load_tokens
 from mcp_spotify_player.spotify_client import SpotifyClient
@@ -38,13 +40,13 @@ def test_invalid_token_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
         client.playback.get_playback_state()
 
 
-def test_expired_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_missing_refresh_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = tmp_path / "tokens.json"
-    data = {"access_token": "a", "refresh_token": "r", "expires_at": 0}
+    data = {"access_token": "a", "refresh_token": "", "expires_at": 0}
     path.write_text(json.dumps(data))
     monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(path))
     tokens = try_load_tokens()
     assert tokens is not None
     client = SpotifyClient(lambda: tokens)
-    with pytest.raises(TokenExpiredError):
+    with pytest.raises(RefreshNotPossibleError):
         client.playback.get_playback_state()

--- a/tests/auth/test_tokens_validation.py
+++ b/tests/auth/test_tokens_validation.py
@@ -31,7 +31,7 @@ def test_missing_keys(tmp_path: Path) -> None:
 
 def test_wrong_types(tmp_path: Path) -> None:
     path = tmp_path / "tokens.json"
-    path.write_text('{"access_token": 123, "refresh_token": "r", "expires_at": "now"}')
+    path.write_text('{"access_token": 123, "refresh_token": "r", "expires_at": "1"}')
     with pytest.raises(InvalidTokenFileError) as exc:
         load_tokens(path)
     assert "invalid types" in str(exc.value)


### PR DESCRIPTION
## Summary
- add token refresh helpers and error
- automatically refresh access token in Spotify client
- cover refresh logic with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b6b4a545c832c8e425d33e8c45e91