### PR TITLE
Add scope verification and Spotify error mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ If `MCP_SPOTIFY_TOKENS_PATH` is not set, tokens will be stored in
 {
   "access_token": "ACCESS",
   "refresh_token": "REFRESH",
-  "expires_at": 1700000000
+  "expires_at": 1700000000,
+  "scopes": ["user-read-playback-state", "user-modify-playback-state"]
 }
 ```
 
@@ -123,6 +124,14 @@ Once authenticated, you can use these commands:
 - `rename_playlist` — "Rename playlist 'Road Trip' to 'Vacation'"
 - `clear_playlist` — "Remove all songs from playlist 'Road Trip'"
 - `add_tracks_to_playlist` — "Add these songs to playlist 'Road Trip'"
+
+### Required scopes
+
+| Feature | Scopes |
+| ------- | ------ |
+| Playback control & status | `user-read-playback-state`, `user-modify-playback-state`, `user-read-currently-playing` |
+| Playlist management | `playlist-read-private`, `playlist-read-collaborative`, `playlist-modify-private` |
+| Library access | `user-library-read`, `user-library-modify` |
 
 ## 🔧 Development
 

--- a/src/mcp_spotify/errors.py
+++ b/src/mcp_spotify/errors.py
@@ -20,3 +20,20 @@ class TokenExpiredError(McpUserError):
 class RefreshNotPossibleError(McpUserError):
     """Raised when refreshing the Spotify access token is not possible."""
 
+
+class MissingScopesError(McpUserError):
+    """Raised when the OAuth token lacks required scopes."""
+
+    def __init__(self, scopes: set[str]):
+        message = ", ".join(sorted(scopes))
+        super().__init__(f"Missing required scopes: {message}")
+        self.scopes = scopes
+
+
+class PremiumRequiredError(McpUserError):
+    """Raised when an operation requires Spotify Premium."""
+
+
+class NoActiveDeviceError(McpUserError):
+    """Raised when there is no active playback device."""
+

--- a/src/mcp_spotify_player/client_auth.py
+++ b/src/mcp_spotify_player/client_auth.py
@@ -42,6 +42,7 @@ class SpotifyAuthClient:
         self.access_token = None
         self.refresh_token = None
         self.token_expires_at = 0
+        self.scopes: list[str] = []
         self.config = Config()
 
         # Get project dir path
@@ -80,7 +81,7 @@ class SpotifyAuthClient:
             token_data = response.json()
             self.access_token = token_data["access_token"]
             self.refresh_token = token_data.get("refresh_token")
-
+            self.scopes = token_data.get("scope", "").split()
             self.token_expires_at = int(time.time()) + int(token_data["expires_in"])
             self._save_tokens()
             return True
@@ -113,6 +114,7 @@ class SpotifyAuthClient:
             "access_token": self.access_token,
             "refresh_token": self.refresh_token,
             "expires_at": int(self.token_expires_at),
+            "scopes": self.scopes,
         }
         os.makedirs(os.path.dirname(self.tokens_file), exist_ok=True)
         with open(self.tokens_file, "w") as f:
@@ -126,6 +128,7 @@ class SpotifyAuthClient:
             self.access_token = token_data["access_token"]
             self.refresh_token = token_data["refresh_token"]
             self.token_expires_at = token_data["expires_at"]
+            self.scopes = token_data.get("scopes", [])
             return True
         except FileNotFoundError:
             return False

--- a/src/mcp_spotify_player/client_playback.py
+++ b/src/mcp_spotify_player/client_playback.py
@@ -17,7 +17,9 @@ class SpotifyPlaybackClient:
             data['context_uri'] = context_uri
         elif uris:
             data['uris'] = uris
-        result = self.requester._make_request('PUT', '/me/player/play', json=data)
+        result = self.requester._make_request(
+            'PUT', '/me/player/play', feature='playback', json=data
+        )
         sys.stderr.write(f"DEBUG: Received response: {result}\n")
         if result is not None:
             return result
@@ -27,24 +29,26 @@ class SpotifyPlaybackClient:
 
     def pause(self) -> bool:
         """Pause playback"""
-        result = self.requester._make_request('PUT', '/me/player/pause')
+        result = self.requester._make_request('PUT', '/me/player/pause', feature='playback')
         return result is not None
 
     def skip_next(self) -> bool:
         """Skip to the next song"""
-        result = self.requester._make_request('POST', '/me/player/next')
+        result = self.requester._make_request('POST', '/me/player/next', feature='playback')
         return result is not None
 
     def skip_previous(self) -> bool:
         """Skip to the previous song"""
-        result = self.requester._make_request('POST', '/me/player/previous')
+        result = self.requester._make_request('POST', '/me/player/previous', feature='playback')
         return result is not None
 
     def set_volume(self, volume_percent: int) -> bool:
         """Sets the volume (0-100)"""
         if not 0 <= volume_percent <= 100:
             return False
-        result = self.requester._make_request('PUT', f'/me/player/volume?volume_percent={volume_percent}')
+        result = self.requester._make_request(
+            'PUT', f'/me/player/volume?volume_percent={volume_percent}', feature='playback'
+        )
         return result is not None
 
     def set_repeat(self, state: str, device_id: Optional[str] = None) -> bool:
@@ -54,21 +58,23 @@ class SpotifyPlaybackClient:
         params = {'state': state}
         if device_id:
             params['device_id'] = device_id
-        result = self.requester._make_request('PUT', '/me/player/repeat', params=params)
+        result = self.requester._make_request(
+            'PUT', '/me/player/repeat', feature='playback', params=params
+        )
         logging.info(f"DEBUG: Setting repeat state to {state} with params {params} result: {result}")
         return result is not None
 
     def get_current_playing(self) -> Optional[Dict[str, Any]]:
         """Gets the information of the currently playing song"""
-        return self.requester._make_request('GET', '/me/player/currently-playing')
+        return self.requester._make_request('GET', '/me/player/currently-playing', feature='playback')
 
     def get_playback_state(self) -> Optional[Dict[str, Any]]:
         """Gets the current playback status"""
-        return self.requester._make_request('GET', '/me/player')
+        return self.requester._make_request('GET', '/me/player', feature='playback')
 
     def get_devices(self) -> Optional[Dict[str, Any]]:
         """Get available playback devices"""
-        return self.requester._make_request('GET', '/me/player/devices')
+        return self.requester._make_request('GET', '/me/player/devices', feature='playback')
 
     def _search(self, query: str, type_: str, limit: int = 10) -> Optional[Dict[str, Any]]:
         """Internal helper to perform a search request against Spotify."""

--- a/src/mcp_spotify_player/client_playlists.py
+++ b/src/mcp_spotify_player/client_playlists.py
@@ -15,7 +15,7 @@ class SpotifyPlaylistsClient:
     def get_user_playlists(self, limit: int = 20) -> Optional[Dict[str, Any]]:
         """Gets the user's playlists"""
         params = {'limit': limit}
-        return self.requester._make_request('GET', '/me/playlists', params=params)
+        return self.requester._make_request('GET', '/me/playlists', feature='playlists', params=params)
 
     def create_playlist(
         self,
@@ -36,7 +36,7 @@ class SpotifyPlaylistsClient:
             'public': public,
         }
         result = self.requester._make_request(
-            'POST', f"/users/{user_profile['id']}/playlists", json=payload
+            'POST', f"/users/{user_profile['id']}/playlists", feature='playlists', json=payload
         )
         sys.stderr.write(
             f"DEBUG: Response creating playlist {playlist_name}: {result}\n"
@@ -46,7 +46,7 @@ class SpotifyPlaylistsClient:
     def get_playlist_tracks(self, playlist_id: str, limit: int = 20) -> Optional[Dict[str, Any]]:
         """Gets songs from a playlist"""
         params = {'limit': limit}
-        return self.requester._make_request('GET', f'/playlists/{playlist_id}/tracks', params=params)
+        return self.requester._make_request('GET', f'/playlists/{playlist_id}/tracks', feature='playlists', params=params)
 
     def rename_playlist(self, playlist_id: str, playlist_name: str) -> bool:
         """Rename a playlist from the user's library"""
@@ -54,6 +54,7 @@ class SpotifyPlaylistsClient:
         result = self.requester._make_request(
             'PUT',
             f'/playlists/{playlist_id}',
+            feature='playlists',
             json={"name": playlist_name}
         )
         sys.stderr.write(f"DEBUG: Response renaming playlist by id {playlist_id}: {result}\n")
@@ -65,6 +66,7 @@ class SpotifyPlaylistsClient:
         result = self.requester._make_request(
             'PUT',
             f'/playlists/{playlist_id}/tracks',
+            feature='playlists',
             json={"uris": []}
         )
         sys.stderr.write(f"DEBUG: Response clearing playlist by id {playlist_id}: {result}\n")
@@ -76,6 +78,7 @@ class SpotifyPlaylistsClient:
         result = self.requester._make_request(
             'POST',
             f'/playlists/{playlist_id}/tracks',
+            feature='playlists',
             json={'uris': track_uris},
         )
         sys.stderr.write(f"DEBUG: Response adding tracks to playlist {playlist_id}: {result}\n")

--- a/src/mcp_spotify_player/spotify_client.py
+++ b/src/mcp_spotify_player/spotify_client.py
@@ -2,8 +2,19 @@ from typing import Callable, Optional
 
 import requests
 
-from mcp_spotify.auth.tokens import Tokens, needs_refresh, refresh_tokens
-from mcp_spotify.errors import NotAuthenticatedError
+from mcp_spotify.auth.tokens import (
+    REQUIRED_SCOPES,
+    Tokens,
+    check_scopes,
+    needs_refresh,
+    refresh_tokens,
+)
+from mcp_spotify.errors import (
+    MissingScopesError,
+    NoActiveDeviceError,
+    NotAuthenticatedError,
+    PremiumRequiredError,
+)
 from mcp_spotify_player.client_playback import SpotifyPlaybackClient
 from mcp_spotify_player.client_playlists import SpotifyPlaylistsClient
 from mcp_spotify_player.config import Config
@@ -15,23 +26,40 @@ TokensProvider = Callable[[], Optional[Tokens]]
 class SpotifyClient:
     """Unified interface to the Spotify Web API."""
 
-    def __init__(self, tokens_provider: TokensProvider | None = None):
+    def __init__(
+        self,
+        tokens_provider: TokensProvider | None = None,
+        *,
+        verify_scopes: bool = False,
+        verify_at_startup: bool = False,
+    ):
         self.tokens_provider: TokensProvider = tokens_provider or (lambda: None)
         self.config = Config()
         self.playback = SpotifyPlaybackClient(self)
         self.playlists = SpotifyPlaylistsClient(self)
+        self.verify_scopes = verify_scopes
+        if verify_at_startup:
+            tokens = self.tokens_provider()
+            if tokens:
+                all_scopes = set().union(*REQUIRED_SCOPES.values())
+                check_scopes(tokens, all_scopes)
 
     def _refresh(self, tokens: Tokens) -> Tokens:
         return refresh_tokens(
             tokens, self.config.SPOTIFY_CLIENT_ID, self.config.SPOTIFY_CLIENT_SECRET
         )
 
-    def _make_request(self, method: str, endpoint: str, **kwargs):
+    def _make_request(
+        self, method: str, endpoint: str, *, feature: str | None = None, **kwargs
+    ):
         tokens = self.tokens_provider()
         if tokens is None:
             raise NotAuthenticatedError("Not authenticated with Spotify. Run /auth.")
         if needs_refresh(tokens):
             tokens = self._refresh(tokens)
+
+        if feature and self.verify_scopes:
+            check_scopes(tokens, REQUIRED_SCOPES[feature])
 
         headers = {
             "Authorization": f"Bearer {tokens.access_token}",
@@ -54,9 +82,36 @@ class SpotifyClient:
                 return True
 
         try:
-            return response.json()
+            data = response.json()
         except Exception:
-            return {"error": response.text}
+            data = {"error": response.text}
+
+        if response.status_code == 403:
+            reason = ""
+            err = data.get("error", {}) if isinstance(data, dict) else {}
+            if isinstance(err, dict):
+                reason = err.get("reason") or err.get("message", "")
+            if reason == "PREMIUM_REQUIRED":
+                raise PremiumRequiredError("Spotify Premium required.")
+            if "scope" in reason.lower() and feature:
+                check_scopes(tokens, REQUIRED_SCOPES[feature])
+            return data
+
+        if (
+            response.status_code == 404
+            and endpoint.startswith("/me/player")
+        ):
+            message = ""
+            err = data.get("error", {}) if isinstance(data, dict) else {}
+            if isinstance(err, dict):
+                message = err.get("message", "")
+            if message in ("Device not found", "No active device"):
+                raise NoActiveDeviceError(
+                    "No active device. Open Spotify on any device."
+                )
+            return data
+
+        return data
 
     def __getattr__(self, name):
         for client in (self.playback, self.playlists):

--- a/src/mcp_spotify_player/spotify_client.py
+++ b/src/mcp_spotify_player/spotify_client.py
@@ -10,7 +10,6 @@ from mcp_spotify.auth.tokens import (
     refresh_tokens,
 )
 from mcp_spotify.errors import (
-    MissingScopesError,
     NoActiveDeviceError,
     NotAuthenticatedError,
     PremiumRequiredError,

--- a/tests/test_clear_playlist.py
+++ b/tests/test_clear_playlist.py
@@ -11,7 +11,10 @@ def test_spotify_client_clear_playlist():
     with patch.object(client, "_make_request", return_value={}) as mock_request:
         assert client.clear_playlist("playlist123") is True
         mock_request.assert_called_once_with(
-            "PUT", "/playlists/playlist123/tracks", json={"uris": []}
+            "PUT",
+            "/playlists/playlist123/tracks",
+            feature="playlists",
+            json={"uris": []},
         )
 
 

--- a/tests/test_error_mapping.py
+++ b/tests/test_error_mapping.py
@@ -1,0 +1,76 @@
+import json
+import time
+
+import pytest
+import requests
+
+from mcp_spotify.auth.tokens import Tokens, REQUIRED_SCOPES, check_scopes
+from mcp_spotify.errors import (
+    MissingScopesError,
+    NoActiveDeviceError,
+    PremiumRequiredError,
+)
+from mcp_spotify_player.spotify_client import SpotifyClient
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, data: dict | None = None):
+        self.status_code = status_code
+        self._data = data or {}
+        self.text = json.dumps(self._data) if self._data else ""
+
+    def json(self):
+        return self._data
+
+
+def _fresh_tokens(scopes: set[str] | None = None) -> Tokens:
+    return Tokens(
+        "a",
+        "r",
+        int(time.time()) + 3600,
+        scopes=scopes or set(),
+    )
+
+
+def test_check_scopes_missing():
+    tokens = _fresh_tokens({"a"})
+    with pytest.raises(MissingScopesError) as exc:
+        check_scopes(tokens, {"a", "b"})
+    assert exc.value.scopes == {"b"}
+
+
+def test_premium_required_mapping(monkeypatch: pytest.MonkeyPatch):
+    tokens = _fresh_tokens(REQUIRED_SCOPES["playback"])
+    response = DummyResponse(
+        403,
+        {"error": {"status": 403, "reason": "PREMIUM_REQUIRED"}},
+    )
+    monkeypatch.setattr(requests, "request", lambda *args, **kwargs: response)
+    client = SpotifyClient(lambda: tokens)
+    with pytest.raises(PremiumRequiredError):
+        client.playback.play()
+
+
+def test_missing_scope_mapping(monkeypatch: pytest.MonkeyPatch):
+    tokens = _fresh_tokens({"user-read-playback-state"})
+    response = DummyResponse(
+        403,
+        {"error": {"status": 403, "reason": "MISSING_SCOPE"}},
+    )
+    monkeypatch.setattr(requests, "request", lambda *args, **kwargs: response)
+    client = SpotifyClient(lambda: tokens)
+    with pytest.raises(MissingScopesError) as exc:
+        client.playback.play()
+    assert "user-modify-playback-state" in exc.value.scopes
+
+
+def test_no_active_device_mapping(monkeypatch: pytest.MonkeyPatch):
+    tokens = _fresh_tokens(REQUIRED_SCOPES["playback"])
+    response = DummyResponse(
+        404,
+        {"error": {"status": 404, "message": "No active device"}},
+    )
+    monkeypatch.setattr(requests, "request", lambda *args, **kwargs: response)
+    client = SpotifyClient(lambda: tokens)
+    with pytest.raises(NoActiveDeviceError):
+        client.playback.play()

--- a/tests/test_set_repeat_client.py
+++ b/tests/test_set_repeat_client.py
@@ -5,8 +5,8 @@ def test_set_repeat_client():
     client = SpotifyClient()
     calls = []
 
-    def fake_make_request(method, endpoint, params=None, json=None):
-        calls.append({'method': method, 'endpoint': endpoint, 'params': params})
+    def fake_make_request(method, endpoint, **kwargs):
+        calls.append({'method': method, 'endpoint': endpoint, 'params': kwargs.get('params')})
         return {}
 
     client._make_request = fake_make_request


### PR DESCRIPTION
## Summary
- track granted OAuth scopes and verify them against REQUIRED_SCOPES
- map common Spotify HTTP errors to user-friendly exceptions
- document required Spotify scopes per feature and expand tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b7d07e3e0832c98663bbdf4a099e9