### PR TITLE
Add queue add playback feature

### DIFF
--- a/src/mcp_spotify_player/client_playback.py
+++ b/src/mcp_spotify_player/client_playback.py
@@ -64,6 +64,17 @@ class SpotifyPlaybackClient:
         logging.info(f"DEBUG: Setting repeat state to {state} with params {params} result: {result}")
         return result is not None
 
+    def add_to_queue(self, uri: str, device_id: str | None = None) -> None:
+        """Add a track or episode to the user's queue."""
+        params = {"uri": uri}
+        if device_id:
+            params["device_id"] = device_id
+        result = self.requester._make_request(
+            "POST", "/me/player/queue", feature="playback", params=params
+        )
+        if result is not True:
+            raise RuntimeError("Failed to add item to queue")
+
     def get_current_playing(self) -> Optional[Dict[str, Any]]:
         """Gets the information of the currently playing song"""
         return self.requester._make_request('GET', '/me/player/currently-playing', feature='playback')

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -60,6 +60,18 @@ MANIFEST = {
             }
         },
         {
+            "name": "queue_add",
+            "description": "Add a track/episode URI to the active device queue (optionally to a specific device).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "uri": {"type": "string"},
+                    "device_id": {"type": "string"}
+                },
+                "required": ["uri"]
+            }
+        },
+        {
             "name": "set_volume",
             "description": "Set the playback volume (0-100%)",
             "inputSchema": {

--- a/src/mcp_spotify_player/playback_controller.py
+++ b/src/mcp_spotify_player/playback_controller.py
@@ -1,10 +1,17 @@
 import logging
 from typing import Any, Dict, List, Optional
 
+from mcp_spotify_player.client_playback import SpotifyPlaybackClient
 from mcp_spotify_player.mcp_models import TrackInfo
 from mcp_spotify_player.spotify_client import SpotifyClient
 
 logger = logging.getLogger(__name__)
+
+
+def queue_add(uri: str, device_id: str | None = None) -> dict:
+    playback = SpotifyPlaybackClient()
+    playback.add_to_queue(uri, device_id)
+    return {"status": "ok", "queued_uri": uri, "device_id": device_id}
 
 
 class PlaybackController:

--- a/tests/playback/test_queue_add.py
+++ b/tests/playback/test_queue_add.py
@@ -1,0 +1,70 @@
+import pytest
+
+from mcp_spotify_player.spotify_client import SpotifyClient
+from mcp_spotify_player.playback_controller import queue_add
+import mcp_spotify_player.playback_controller as playback_controller_module
+from mcp_spotify.errors import (
+    NotAuthenticatedError,
+    NoActiveDeviceError,
+    PremiumRequiredError,
+)
+
+
+def test_client_add_to_queue(monkeypatch: pytest.MonkeyPatch):
+    client = SpotifyClient()
+    calls = []
+
+    def fake_make_request(method, endpoint, **kwargs):
+        calls.append((method, endpoint, kwargs))
+        return True
+
+    client._make_request = fake_make_request
+
+    client.playback.add_to_queue("spotify:track:123", "dev1")
+    assert calls[-1][0] == "POST"
+    assert calls[-1][1] == "/me/player/queue"
+    assert calls[-1][2]["params"] == {
+        "uri": "spotify:track:123",
+        "device_id": "dev1",
+    }
+
+    client.playback.add_to_queue("spotify:track:456")
+    assert calls[-1][2]["params"] == {"uri": "spotify:track:456"}
+
+
+def test_queue_add_success(monkeypatch: pytest.MonkeyPatch):
+    recorded: dict[str, str | None] = {}
+
+    class DummyPlayback:
+        def add_to_queue(self, uri: str, device_id: str | None = None):
+            recorded["uri"] = uri
+            recorded["device_id"] = device_id
+
+    monkeypatch.setattr(
+        playback_controller_module, "SpotifyPlaybackClient", lambda: DummyPlayback()
+    )
+
+    result = queue_add("spotify:track:123", "dev1")
+    assert result == {
+        "status": "ok",
+        "queued_uri": "spotify:track:123",
+        "device_id": "dev1",
+    }
+    assert recorded == {"uri": "spotify:track:123", "device_id": "dev1"}
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [NotAuthenticatedError, NoActiveDeviceError, PremiumRequiredError],
+)
+def test_queue_add_errors(monkeypatch: pytest.MonkeyPatch, exc):
+    class DummyPlayback:
+        def add_to_queue(self, uri: str, device_id: str | None = None):
+            raise exc("boom")
+
+    monkeypatch.setattr(
+        playback_controller_module, "SpotifyPlaybackClient", lambda: DummyPlayback()
+    )
+
+    with pytest.raises(exc):
+        queue_add("spotify:track:123")


### PR DESCRIPTION
## Summary
- add `add_to_queue` method to playback client and expose via controller function
- register new `queue_add` tool in manifest
- cover queue add behavior with unit tests

## Testing
- `pytest tests/playback/test_queue_add.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b8582506c832c8433a15bc5351529