### PR TITLE
feat: add playlist and album search tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,5 @@ obtener_token.md
 
 # OS
 .DS_Store
-Thumbs.db 
+Thumbs.db
+.continue/

--- a/README.md
+++ b/README.md
@@ -118,12 +118,31 @@ Once authenticated, you can use these commands:
 - `get_playback_state` — "What's the playback state?"
 - `get_devices` — "List my available devices"
 - `search_music` — "Search for songs by Queen"
+- `search_collections` — "Search for playlists or albums"
 - `get_playlists` — "List my playlists"
 - `get_playlist_tracks` — "Show tracks in playlist 'Road Trip'"
 - `create_playlist` — "Create playlist 'Road Trip' with these songs..."
 - `rename_playlist` — "Rename playlist 'Road Trip' to 'Vacation'"
 - `clear_playlist` — "Remove all songs from playlist 'Road Trip'"
 - `add_tracks_to_playlist` — "Add these songs to playlist 'Road Trip'"
+
+### Search – Playlists & Albums
+
+Use the `search_collections` tool to find public playlists or albums.
+
+```bash
+/search_collections {"q": "study", "type": "playlist", "limit": 5}
+```
+
+Parameters:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `q` | string | Search query (required) |
+| `type` | string | `playlist` or `album` (required) |
+| `limit` | integer | 1–50, default 20 |
+| `offset` | integer | ≥0, default 0 |
+| `market` | string | Optional ISO 3166-1 alpha-2 code |
 
 ### Required scopes
 

--- a/src/mcp_spotify_player/client_playback.py
+++ b/src/mcp_spotify_player/client_playback.py
@@ -106,14 +106,33 @@ class SpotifyPlaybackClient:
         """Get available playback devices"""
         return self.requester._make_request('GET', '/me/player/devices', feature='playback')
 
-    def _search(self, query: str, type_: str, limit: int = 10) -> Optional[Dict[str, Any]]:
+    # def _search(self, query: str, type_: str, limit: int = 10) -> Optional[Dict[str, Any]]:
+    #     """Internal helper to perform a search request against Spotify."""
+    #     params = {
+    #         'q': query,
+    #         'type': type_,
+    #         'limit': limit
+    #     }
+    #     return self.requester._make_request('GET', '/search', params=params)
+
+    def _search(
+            self,
+            query: str,
+            type_: str,
+            limit: int = 10,
+            offset: int = 0,
+            market: str | None = None
+    ) -> Optional[Dict[str, Any]]:
         """Internal helper to perform a search request against Spotify."""
         params = {
             'q': query,
             'type': type_,
-            'limit': limit
+            'limit': limit,
+            'offset': offset
         }
-        return self.requester._make_request('GET', '/search', params=params)
+        if market:
+            params['market'] = market
+        return self.requester._make_request('GET', '/search', params=params, feature='playback')
 
     def search(self, query: str, type_: str, limit: int = 10) -> Optional[Dict[str, Any]]:
         """Search for any supported type on Spotify (track, artist, album, etc.)."""
@@ -127,22 +146,28 @@ class SpotifyPlaybackClient:
         """Search for artists on Spotify."""
         return self._search(query, 'artist', limit)
 
-    def search_collections(
-        self,
-        q: str,
-        type: str,
-        limit: int = 20,
-        offset: int = 0,
-        market: str | None = None,
-    ) -> Optional[Dict[str, Any]]:
+    def search_collections(self, q: str, type: str, limit: int = 20, offset: int = 0, market: str | None = None):
         """Search for playlists or albums on Spotify."""
-        params = {
-            "q": q,
-            "type": type,
-            "limit": limit,
-            "offset": offset,
-        }
-        if market:
-            params["market"] = market
-        logging.info("DEBUG: Searching collections with params: %s", params)
-        return self.requester._make_request("GET", "/search", params=params)
+        return self._search(q, type, limit, offset, market)
+
+    # def search_collections(
+    #     self,
+    #     q: str,
+    #     type: str,
+    #     limit: int = 20,
+    #     offset: int = 0,
+    #     market: str | None = None,
+    # ) -> Optional[Dict[str, Any]]:
+    #     """Search for playlists or albums on Spotify."""
+    #     params = {
+    #         "q": q,
+    #         "type": type,
+    #         "limit": limit,
+    #         "offset": offset,
+    #     }
+    #     if market:
+    #         params["market"] = market
+    #     logging.info("DEBUG: Searching collections with params: %s", params)
+    #     return self.requester._make_request('GET', '/search', params=params)
+
+

--- a/src/mcp_spotify_player/client_playback.py
+++ b/src/mcp_spotify_player/client_playback.py
@@ -126,3 +126,22 @@ class SpotifyPlaybackClient:
     def search_artists(self, query: str, limit: int = 10) -> Optional[Dict[str, Any]]:
         """Search for artists on Spotify."""
         return self._search(query, 'artist', limit)
+
+    def search_collections(
+        self,
+        q: str,
+        type: str,
+        limit: int = 20,
+        offset: int = 0,
+        market: str | None = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Search for playlists or albums on Spotify."""
+        params = {
+            "q": q,
+            "type": type,
+            "limit": limit,
+            "offset": offset,
+        }
+        if market:
+            params["market"] = market
+        return self.requester._make_request("GET", "/search", params=params)

--- a/src/mcp_spotify_player/client_playback.py
+++ b/src/mcp_spotify_player/client_playback.py
@@ -144,4 +144,5 @@ class SpotifyPlaybackClient:
         }
         if market:
             params["market"] = market
+        logging.info("DEBUG: Searching collections with params: %s", params)
         return self.requester._make_request("GET", "/search", params=params)

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -178,6 +178,42 @@ MANIFEST = {
             }
         },
         {
+            "name": "search_collections",
+            "description": "Search for playlists or albums on Spotify",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "q": {
+                        "type": "string",
+                        "description": "Search term",
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["playlist", "album"],
+                        "description": "Type of collection to search",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50,
+                        "default": 20,
+                        "description": "Number of items to return",
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0,
+                        "description": "Index of the first result to return",
+                    },
+                    "market": {
+                        "type": "string",
+                        "description": "ISO 3166-1 alpha-2 market code",
+                    },
+                },
+                "required": ["q", "type"],
+            },
+        },
+        {
             "name": "get_playlists",
             "description": "Retrieve the user's playlists list",
             "inputSchema": {

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -64,6 +64,7 @@ class MCPServer:
             "get_playback_state": self.controller.playback.get_playback_state,
             "get_devices": self.controller.playback.get_devices,
             "search_music": self.controller.playback.search_music,
+            "search_collections": self.controller.playback.search_collections,
             "get_playlists": self.controller.playlists.get_playlists,
             "get_playlist_tracks": self.controller.playlists.get_playlist_tracks,
             "rename_playlist": self.controller.playlists.rename_playlist,
@@ -80,6 +81,7 @@ class MCPServer:
             "set_volume": self._validate_set_volume,
             "set_repeat": self._validate_set_repeat,
             "search_music": self._validate_search_music,
+            "search_collections": self._validate_search_collections,
             "get_playlist_tracks": self._validate_get_playlist_tracks,
             "rename_playlist": self._validate_rename_playlist,
             "clear_playlist": self._validate_clear_playlist,
@@ -94,6 +96,7 @@ class MCPServer:
             "get_playback_state": self._format_get_playback_state,
             "get_devices": self._format_json_result,
             "search_music": self._format_json_result,
+            "search_collections": self._format_json_result,
             "get_playlists": self._format_json_result,
             "get_playlist_tracks": self._format_json_result,
             "queue_list": self._format_json_result,
@@ -242,6 +245,21 @@ class MCPServer:
     def _validate_search_music(self, arguments: Dict[str, Any]):
         if not arguments.get("query"):
             raise ValueError("query is required")
+
+    def _validate_search_collections(self, arguments: Dict[str, Any]):
+        if not arguments.get("q"):
+            raise ValueError("q is required")
+        collection_type = arguments.get("type")
+        if collection_type not in ("playlist", "album"):
+            raise ValueError("type must be 'playlist' or 'album'")
+        limit = arguments.get("limit", 20)
+        if not isinstance(limit, int) or limit < 1 or limit > 50:
+            raise ValueError("limit must be between 1 and 50")
+        offset = arguments.get("offset", 0)
+        if not isinstance(offset, int) or offset < 0:
+            raise ValueError("offset must be >= 0")
+        arguments.setdefault("limit", limit)
+        arguments.setdefault("offset", offset)
 
     def _validate_get_playlist_tracks(self, arguments: Dict[str, Any]):
         playlist_id = arguments.get("playlist_id")

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -348,10 +348,23 @@ class MCPServer:
             return f"No music playing | Volume: {volume}% | Device: {device}"
         return f"Could not retrieve state: {result.get('message', 'Unknown error')}"
 
-    def _format_json_result(self, result: Dict[str, Any], _arguments: Dict[str, Any]) -> str:
-        if result.get("success"):
-            return json.dumps(result)
-        return json.dumps({"success": False, "message": result.get("message", "Unknown error")})
+    def _format_json_result(self, result, _args):
+        """
+        Envuelve cualquier resultado en un sobre estándar y evita petar si el result
+        no es serializable.
+        """
+        try:
+            payload = {"success": True, "data": result}
+            return json.dumps(payload, ensure_ascii=False)
+        except Exception as e:
+            logger.exception("Failed to serialize tool result for %s", _args)
+            return json.dumps({"success": False, "message": str(e) or "Unknown error"})
+
+    # def _format_json_result(self, result: Dict[str, Any], _arguments: Dict[str, Any]) -> str:
+    #     logger.info(f"BBBBBBBBBBBBBBBB formatting result: {result}")
+    #     if result.get("success"):
+    #         return json.dumps(result)
+    #     return json.dumps({"success": False, "message": result.get("message", "Unknown error")})
 
     def run(self):
         """Run the MCP server"""

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -190,6 +190,7 @@ class MCPServer:
 
             result = handler(**arguments)
             formatter = self.RESULT_FORMATTERS.get(tool_name, self._default_formatter)
+            logger.info("AAAAAAAAAAAAAAA executing tool: %s with arguments: %s", tool_name, arguments)
             return formatter(result, arguments)
 
         except McpUserError:

--- a/src/mcp_spotify_player/playback_controller.py
+++ b/src/mcp_spotify_player/playback_controller.py
@@ -288,7 +288,7 @@ class PlaybackController:
                 "items": items,
             }
         except Exception as e:
-            logger.error(f"Error in search_collections: %s", e)
+            logger.error("Error in search_collections: %s", e)
             return {"error": str(e)}
 
     def queue_add(self, uri: str, device_id: str | None = None) -> dict:

--- a/src/mcp_spotify_player/playback_controller.py
+++ b/src/mcp_spotify_player/playback_controller.py
@@ -239,6 +239,54 @@ class PlaybackController:
         except Exception as e:
             return {"success": False, "message": f"Error: {str(e)}"}
 
+    def search_collections(
+        self,
+        q: str,
+        type: str,
+        limit: int = 20,
+        offset: int = 0,
+        market: str | None = None,
+    ) -> Dict[str, Any]:
+        """Search for playlists or albums on Spotify."""
+        try:
+            result = self.playback_client.search_collections(q, type, limit, offset, market)
+            if isinstance(result, dict) and "error" in result:
+                err = result["error"]
+                message = err.get("message", "Unknown error")
+                status = err.get("status")
+                if status is not None:
+                    message = f"{status}: {message}"
+                return {"error": message}
+
+            container_key = "playlists" if type == "playlist" else "albums"
+            if not result or container_key not in result:
+                return {"type": type, "limit": limit, "offset": offset, "total": 0, "items": []}
+
+            container = result[container_key]
+            items: List[Dict[str, Any]] = []
+            for item in container.get("items", []):
+                images = item.get("images", [])
+                image_url = images[0]["url"] if images else None
+                entry = {
+                    "id": item.get("id"),
+                    "name": item.get("name"),
+                    "uri": item.get("uri"),
+                    "image": image_url,
+                }
+                if type == "album":
+                    entry["artists"] = [a.get("name") for a in item.get("artists", [])]
+                items.append(entry)
+
+            return {
+                "type": type,
+                "limit": container.get("limit", limit),
+                "offset": container.get("offset", offset),
+                "total": container.get("total", 0),
+                "items": items,
+            }
+        except Exception as e:
+            return {"error": str(e)}
+
     def queue_add(self, uri: str, device_id: str | None = None) -> dict:
         """Add a track/episode to the active device queue."""
         try:

--- a/src/mcp_spotify_player/playback_controller.py
+++ b/src/mcp_spotify_player/playback_controller.py
@@ -249,45 +249,32 @@ class PlaybackController:
     ) -> Dict[str, Any]:
         """Search for playlists or albums on Spotify."""
         try:
-            logger.info("playback controller [search_collections] q: %s, type: %s, limit: %d, offset: %d, market: %s", q, type, limit, offset, market)
             result = self.playback_client.search_collections(q, type, limit, offset, market)
-            logger.info(f"Result of search collections: {result}")
+
             if isinstance(result, dict) and "error" in result:
                 err = result["error"]
                 message = err.get("message", "Unknown error")
                 status = err.get("status")
                 if status is not None:
                     message = f"{status}: {message}"
-                # Debug: print the full error response for troubleshooting
-                print(f"[DEBUG][search_collections] Full error response: {result}")
                 return {"error": message}
 
-            logger.info("playback controller [search_collections] --> NO ERROR ")
-
             container_key = "playlists" if type == "playlist" else "albums"
-
-            logger.info("playback controller [search_collections] --> container_key: %s", container_key)
-
             if not result or container_key not in result:
                 return {"type": type, "limit": limit, "offset": offset, "total": 0, "items": []}
 
-            logger.info("playback controller [search_collections] --> resultados y container key: %s", result)
-
             container = result[container_key]
 
-            logger.info("playback controller [search_collections] --> container: %s", container);
             items: List[Dict[str, Any]] = []
             for item in container.get("items", []):
                 images = item.get("images", [])
                 image_url = images[0]["url"] if images else None
-                logger.info("playback controller [search_collections] --> image_url: %s", image_url)
                 entry = {
                     "id": item.get("id"),
                     "name": item.get("name"),
                     "uri": item.get("uri"),
                     "image": image_url,
                 }
-                logger.info(f"playback controller [search_collections] --> entry: {entry}")
                 if type == "album":
                     entry["artists"] = [a.get("name") for a in item.get("artists", [])]
                 logger.info("playback controller [search_collections] --> entry with artists: %s", entry)

--- a/src/mcp_spotify_player/playback_controller.py
+++ b/src/mcp_spotify_player/playback_controller.py
@@ -249,32 +249,48 @@ class PlaybackController:
     ) -> Dict[str, Any]:
         """Search for playlists or albums on Spotify."""
         try:
+            logger.info("playback controller [search_collections] q: %s, type: %s, limit: %d, offset: %d, market: %s", q, type, limit, offset, market)
             result = self.playback_client.search_collections(q, type, limit, offset, market)
+            logger.info(f"Result of search collections: {result}")
             if isinstance(result, dict) and "error" in result:
                 err = result["error"]
                 message = err.get("message", "Unknown error")
                 status = err.get("status")
                 if status is not None:
                     message = f"{status}: {message}"
+                # Debug: print the full error response for troubleshooting
+                print(f"[DEBUG][search_collections] Full error response: {result}")
                 return {"error": message}
 
+            logger.info("playback controller [search_collections] --> NO ERROR ")
+
             container_key = "playlists" if type == "playlist" else "albums"
+
+            logger.info("playback controller [search_collections] --> container_key: %s", container_key)
+
             if not result or container_key not in result:
                 return {"type": type, "limit": limit, "offset": offset, "total": 0, "items": []}
 
+            logger.info("playback controller [search_collections] --> resultados y container key: %s", result)
+
             container = result[container_key]
+
+            logger.info("playback controller [search_collections] --> container: %s", container);
             items: List[Dict[str, Any]] = []
             for item in container.get("items", []):
                 images = item.get("images", [])
                 image_url = images[0]["url"] if images else None
+                logger.info("playback controller [search_collections] --> image_url: %s", image_url)
                 entry = {
                     "id": item.get("id"),
                     "name": item.get("name"),
                     "uri": item.get("uri"),
                     "image": image_url,
                 }
+                logger.info(f"playback controller [search_collections] --> entry: {entry}")
                 if type == "album":
                     entry["artists"] = [a.get("name") for a in item.get("artists", [])]
+                logger.info("playback controller [search_collections] --> entry with artists: %s", entry)
                 items.append(entry)
 
             return {
@@ -285,6 +301,7 @@ class PlaybackController:
                 "items": items,
             }
         except Exception as e:
+            logger.error(f"Error in search_collections: %s", e)
             return {"error": str(e)}
 
     def queue_add(self, uri: str, device_id: str | None = None) -> dict:

--- a/tests/test_search_collections.py
+++ b/tests/test_search_collections.py
@@ -1,0 +1,117 @@
+import os
+import sys
+from unittest.mock import patch
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from mcp_spotify_player.playback_controller import PlaybackController
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+
+
+def test_search_collections_playlist():
+    class DummyPlayback:
+        def search_collections(self, q, type, limit, offset, market):
+            assert market is None
+            return {
+                "playlists": {
+                    "limit": limit,
+                    "offset": offset,
+                    "total": 1,
+                    "items": [
+                        {
+                            "id": "p1",
+                            "name": "Mix",
+                            "uri": "spotify:playlist:p1",
+                            "images": [{"url": "http://img"}],
+                        }
+                    ],
+                }
+            }
+
+    dummy_client = type("Dummy", (), {"playback": DummyPlayback(), "playlists": None})()
+    controller = PlaybackController(dummy_client)
+    result = controller.search_collections(q="mix", type="playlist", limit=1)
+    assert result == {
+        "type": "playlist",
+        "limit": 1,
+        "offset": 0,
+        "total": 1,
+        "items": [
+            {"id": "p1", "name": "Mix", "uri": "spotify:playlist:p1", "image": "http://img"}
+        ],
+    }
+    assert "artists" not in result["items"][0]
+
+
+def test_search_collections_album_with_market():
+    class DummyPlayback:
+        def search_collections(self, q, type, limit, offset, market):
+            assert market == "US"
+            assert offset == 2
+            return {
+                "albums": {
+                    "limit": limit,
+                    "offset": offset,
+                    "total": 1,
+                    "items": [
+                        {
+                            "id": "a1",
+                            "name": "Album",
+                            "uri": "spotify:album:a1",
+                            "images": [{"url": "http://img"}],
+                            "artists": [{"name": "Artist"}],
+                        }
+                    ],
+                }
+            }
+
+    dummy_client = type("Dummy", (), {"playback": DummyPlayback(), "playlists": None})()
+    controller = PlaybackController(dummy_client)
+    result = controller.search_collections(q="alb", type="album", limit=1, offset=2, market="US")
+    assert result["type"] == "album"
+    assert result["offset"] == 2
+    assert result["items"][0]["artists"] == ["Artist"]
+
+
+# Validation tests
+
+def _server():
+    with patch("mcp_spotify_player.mcp_stdio_server.try_load_tokens", return_value=None):
+        return MCPServer()
+
+
+def test_validate_search_collections_invalid_type():
+    server = _server()
+    with pytest.raises(ValueError):
+        server._validate_search_collections({"q": "a", "type": "track"})
+
+
+def test_validate_search_collections_invalid_limit():
+    server = _server()
+    with pytest.raises(ValueError):
+        server._validate_search_collections({"q": "a", "type": "album", "limit": 0})
+
+
+# Error handling tests
+
+def test_search_collections_http_401():
+    class DummyPlayback:
+        def search_collections(self, q, type, limit, offset, market):
+            return {"error": {"status": 401, "message": "Unauthorized"}}
+
+    dummy_client = type("Dummy", (), {"playback": DummyPlayback(), "playlists": None})()
+    controller = PlaybackController(dummy_client)
+    result = controller.search_collections(q="x", type="playlist")
+    assert "Unauthorized" in result["error"]
+
+
+def test_search_collections_http_429():
+    class DummyPlayback:
+        def search_collections(self, q, type, limit, offset, market):
+            return {"error": {"status": 429, "message": "Too Many Requests"}}
+
+    dummy_client = type("Dummy", (), {"playback": DummyPlayback(), "playlists": None})()
+    controller = PlaybackController(dummy_client)
+    result = controller.search_collections(q="x", type="playlist")
+    assert "429" in result["error"]

--- a/tests/test_search_simple.py
+++ b/tests/test_search_simple.py
@@ -13,7 +13,7 @@ def test_search_methods():
     client = SpotifyClient()
     calls = []
 
-    def fake_make_request(method, endpoint, params=None, json=None):
+    def fake_make_request(method, endpoint, params=None, json=None, **kwargs):
         calls.append({'method': method, 'endpoint': endpoint, 'params': params})
         return {'ok': True}
 
@@ -22,15 +22,15 @@ def test_search_methods():
     # search_tracks wrapper
     result = client.search_tracks('jazz', limit=5)
     assert result == {'ok': True}
-    assert calls[-1]['params'] == {'q': 'jazz', 'type': 'track', 'limit': 5}
+    assert calls[-1]['params'] == {'q': 'jazz', 'type': 'track', 'limit': 5, 'offset': 0}
 
     # search_artists wrapper
     result = client.search_artists('miles', limit=3)
     assert result == {'ok': True}
-    assert calls[-1]['params'] == {'q': 'miles', 'type': 'artist', 'limit': 3}
+    assert calls[-1]['params'] == {'q': 'miles', 'type': 'artist', 'limit': 3, 'offset': 0}
 
     # generic search for albums
     result = client.search('blue', type_='album', limit=2)
     assert result == {'ok': True}
-    assert calls[-1]['params'] == {'q': 'blue', 'type': 'album', 'limit': 2}
+    assert calls[-1]['params'] == {'q': 'blue', 'type': 'album', 'limit': 2, 'offset': 0}
 


### PR DESCRIPTION
## Summary
- add `search_collections` tool to query Spotify playlists or albums
- wire new tool into MCP server manifest and validator logic
- document playlist/album search and add unit tests for success, validation and HTTP errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f6061dcb8832cae80683c46b34ea4