### PR TITLE
Centralize logging configuration

### DIFF
--- a/src/mcp_logging/__init__.py
+++ b/src/mcp_logging/__init__.py
@@ -1,0 +1,34 @@
+"""Centralized logging configuration for mcp-spotify-player.
+
+This module exposes a :func:`get_logger` helper that other modules should
+use instead of configuring logging individually. Logging output can be
+customised via environment variables:
+
+- ``MCP_LOG_LEVEL`` sets the minimum log level (default: ``INFO``).
+- ``MCP_LOG_FILE``  if set, log output will also be written to this file
+  in addition to stderr.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+_LOG_LEVEL = os.getenv("MCP_LOG_LEVEL", "INFO").upper()
+_LOG_FORMAT = (
+    "%(asctime)s [%(levelname)s] %(filename)s:%(funcName)s - %(message)s"
+)
+_LOG_FILE = os.getenv("MCP_LOG_FILE")
+
+_handlers: list[logging.Handler] = [logging.StreamHandler()]
+if _LOG_FILE:
+    _handlers.append(logging.FileHandler(_LOG_FILE))
+
+logging.basicConfig(level=_LOG_LEVEL, format=_LOG_FORMAT, handlers=_handlers)
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a module-specific logger.
+
+    ``name`` defaults to ``"mcp"`` when ``None`` is provided.
+    """
+    return logging.getLogger(name or "mcp")

--- a/src/mcp_logging/__init__.py
+++ b/src/mcp_logging/__init__.py
@@ -22,9 +22,10 @@ _LOG_FILE = os.getenv("MCP_LOG_FILE")
 
 _handlers: list[logging.Handler] = [logging.StreamHandler()]
 if _LOG_FILE:
-    _handlers.append(logging.FileHandler(_LOG_FILE))
+    _handlers.append(logging.FileHandler(_LOG_FILE, encoding="utf-8"))
 
 logging.basicConfig(level=_LOG_LEVEL, format=_LOG_FORMAT, handlers=_handlers)
+
 
 def get_logger(name: str | None = None) -> logging.Logger:
     """Return a module-specific logger.

--- a/src/mcp_spotify/auth/tokens.py
+++ b/src/mcp_spotify/auth/tokens.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -15,7 +14,9 @@ from mcp_spotify.errors import (
     RefreshNotPossibleError,
 )
 from mcp_spotify_player.config import Config, resolve_tokens_path
+from mcp_logging import get_logger
 
+logger = get_logger(__name__)
 
 @dataclass(slots=True)
 class Tokens:
@@ -111,7 +112,7 @@ def load_tokens(path: Path) -> Tokens:
     InvalidTokenFileError
         If the file is missing, malformed, or lacks required fields.
     """
-    logging.info(f"Loading tokens from {path}")
+    logger.info("Loading tokens from %s", path)
     if not path.exists():
         raise InvalidTokenFileError(f"Token file not found: {path}")
 
@@ -132,7 +133,7 @@ def load_tokens(path: Path) -> Tokens:
     invalid: list[str] = []
 
     for key, typ in required:
-        logging.info(f"Checking key '{key}' of type {typ.__name__}. Value: {data.get(key)}")
+        logger.info("Checking key '%s' of type %s. Value: %s", key, typ.__name__, data.get(key))
         if key not in data:
             missing.append(key)
         elif not isinstance(data[key], typ):

--- a/src/mcp_spotify_player/cli.py
+++ b/src/mcp_spotify_player/cli.py
@@ -1,7 +1,10 @@
 import argparse
 import sys
 
+from mcp_logging import get_logger
 from .mcp_stdio_server import MCPServer
+
+logger = get_logger(__name__)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -10,20 +13,20 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--version", action="version", version="0.1.0")
     parser.parse_args(argv)
 
-    print("MCP Spotify Player - stdio server", file=sys.stderr)
-    print("=" * 50, file=sys.stderr)
-    print("Initializying MCP server...", file=sys.stderr)
-    print("This server connect to Cursor through STDIO", file=sys.stderr)
-    print("Do not open browser, this server is not using HTTP", file=sys.stderr)
-    print("=" * 50, file=sys.stderr)
+    logger.info("MCP Spotify Player - stdio server")
+    logger.info("=" * 50)
+    logger.info("Initializying MCP server...")
+    logger.info("This server connect to Cursor through STDIO")
+    logger.info("Do not open browser, this server is not using HTTP")
+    logger.info("=" * 50)
 
     try:
         server = MCPServer()
         server.run()
     except KeyboardInterrupt:
-        print("\nServer stopped by user", file=sys.stderr)
+        logger.info("\nServer stopped by user")
     except Exception as e:  # pragma: no cover - defensive
-        print(f"Error initializing server: {e}", file=sys.stderr)
+        logger.error("Error initializing server: %s", e)
         sys.exit(1)
 
 

--- a/src/mcp_spotify_player/client_playback.py
+++ b/src/mcp_spotify_player/client_playback.py
@@ -1,6 +1,8 @@
-import logging
-import sys
 from typing import Any, Dict, List, Optional
+
+from mcp_logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class SpotifyPlaybackClient:
@@ -20,11 +22,11 @@ class SpotifyPlaybackClient:
         result = self.requester._make_request(
             'PUT', '/me/player/play', feature='playback', json=data
         )
-        sys.stderr.write(f"DEBUG: Received response: {result}\n")
+        logger.debug("Received response: %s", result)
         if result is not None:
             return result
         else:
-            sys.stderr.write(f"DEBUG: Error initializing playback: {result}\n")
+            logger.debug("Error initializing playback: %s", result)
             return {"error": "Playback failed. Please check that you have an active device on Spotify."}
 
     def pause(self) -> bool:
@@ -61,7 +63,7 @@ class SpotifyPlaybackClient:
         result = self.requester._make_request(
             'PUT', '/me/player/repeat', feature='playback', params=params
         )
-        logging.info(f"DEBUG: Setting repeat state to {state} with params {params} result: {result}")
+        logger.debug("Setting repeat state to %s with params %s result: %s", state, params, result)
         return result is not None
 
     def add_to_queue(self, uri: str, device_id: str | None = None) -> None:
@@ -167,7 +169,7 @@ class SpotifyPlaybackClient:
     #     }
     #     if market:
     #         params["market"] = market
-    #     logging.info("DEBUG: Searching collections with params: %s", params)
+    #     logger.debug("Searching collections with params: %s", params)
     #     return self.requester._make_request('GET', '/search', params=params)
 
 

--- a/src/mcp_spotify_player/client_playlists.py
+++ b/src/mcp_spotify_player/client_playlists.py
@@ -1,8 +1,8 @@
-import logging
-import sys
 from typing import Any, Dict, List, Optional
 
-logger = logging.getLogger(__name__)
+from mcp_logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class SpotifyPlaylistsClient:
@@ -25,7 +25,7 @@ class SpotifyPlaylistsClient:
     ) -> Optional[Dict[str, Any]]:
         """Create a new playlist for the current user."""
         logger.info(
-            f"DEBUG: spotify_client -- Creating playlist with name {playlist_name}"
+            "spotify_client -- Creating playlist with name %s", playlist_name
         )
         user_profile = self.requester._make_request('GET', '/me')
         if not user_profile or 'id' not in user_profile:
@@ -38,9 +38,7 @@ class SpotifyPlaylistsClient:
         result = self.requester._make_request(
             'POST', f"/users/{user_profile['id']}/playlists", feature='playlists', json=payload
         )
-        sys.stderr.write(
-            f"DEBUG: Response creating playlist {playlist_name}: {result}\n"
-        )
+        logger.debug("Response creating playlist %s: %s", playlist_name, result)
         return result
 
     def get_playlist_tracks(self, playlist_id: str, limit: int = 20) -> Optional[Dict[str, Any]]:
@@ -50,36 +48,36 @@ class SpotifyPlaylistsClient:
 
     def rename_playlist(self, playlist_id: str, playlist_name: str) -> bool:
         """Rename a playlist from the user's library"""
-        logger.info(f"DEBUG: spotify_client -- Renaming playlist with id {playlist_id}")
+        logger.info("spotify_client -- Renaming playlist with id %s", playlist_id)
         result = self.requester._make_request(
             'PUT',
             f'/playlists/{playlist_id}',
             feature='playlists',
             json={"name": playlist_name}
         )
-        sys.stderr.write(f"DEBUG: Response renaming playlist by id {playlist_id}: {result}\n")
+        logger.debug("Response renaming playlist by id %s: %s", playlist_id, result)
         return result is not None
 
     def clear_playlist(self, playlist_id: str) -> bool:
         """Remove all tracks from a playlist"""
-        logger.info(f"DEBUG: spotify_client -- Clearing playlist with id {playlist_id}")
+        logger.info("spotify_client -- Clearing playlist with id %s", playlist_id)
         result = self.requester._make_request(
             'PUT',
             f'/playlists/{playlist_id}/tracks',
             feature='playlists',
             json={"uris": []}
         )
-        sys.stderr.write(f"DEBUG: Response clearing playlist by id {playlist_id}: {result}\n")
+        logger.debug("Response clearing playlist by id %s: %s", playlist_id, result)
         return result is not None
 
     def add_tracks_to_playlist(self, playlist_id: str, track_uris: List[str]) -> bool:
         """Add tracks to a playlist"""
-        logger.info(f"DEBUG: spotify_client -- Adding tracks to playlist {playlist_id}")
+        logger.info("spotify_client -- Adding tracks to playlist %s", playlist_id)
         result = self.requester._make_request(
             'POST',
             f'/playlists/{playlist_id}/tracks',
             feature='playlists',
             json={'uris': track_uris},
         )
-        sys.stderr.write(f"DEBUG: Response adding tracks to playlist {playlist_id}: {result}\n")
+        logger.debug("Response adding tracks to playlist %s: %s", playlist_id, result)
         return result is not None

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -5,12 +5,13 @@ Implements the MCP protocol over JSON-RPC for communication with Cursor
 """
 
 import json
-import logging
 import sys
 import time
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 import platform
+
+from mcp_logging import get_logger
 
 import mcp_spotify_player
 
@@ -22,8 +23,7 @@ from mcp_spotify_player.mcp_manifest import MANIFEST
 from mcp_spotify_player.spotify_controller import SpotifyController
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class MCPServer:

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -190,7 +190,7 @@ class MCPServer:
 
             result = handler(**arguments)
             formatter = self.RESULT_FORMATTERS.get(tool_name, self._default_formatter)
-            logger.info("AAAAAAAAAAAAAAA executing tool: %s with arguments: %s", tool_name, arguments)
+            logger.info("Executing tool: %s with arguments: %s", tool_name, arguments)
             return formatter(result, arguments)
 
         except McpUserError:

--- a/src/mcp_spotify_player/playback_controller.py
+++ b/src/mcp_spotify_player/playback_controller.py
@@ -1,10 +1,11 @@
-import logging
 from typing import Any, Dict, List, Optional
+
+from mcp_logging import get_logger
 
 from mcp_spotify_player.mcp_models import TrackInfo
 from mcp_spotify_player.spotify_client import SpotifyClient
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class PlaybackController:

--- a/src/mcp_spotify_player/playlist_controller.py
+++ b/src/mcp_spotify_player/playlist_controller.py
@@ -1,10 +1,11 @@
-import logging
 from typing import Any, Dict, List
+
+from mcp_logging import get_logger
 
 from mcp_spotify_player.mcp_models import PlaylistInfo, TrackInfo
 from mcp_spotify_player.spotify_client import SpotifyClient
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class PlaylistController:

--- a/src/mcp_spotify_player/spotify_controller.py
+++ b/src/mcp_spotify_player/spotify_controller.py
@@ -1,5 +1,6 @@
-import logging
 from typing import Any, Callable, Optional
+
+from mcp_logging import get_logger
 
 from mcp_spotify.auth.tokens import Tokens
 from mcp_spotify.errors import InvalidTokenFileError
@@ -8,7 +9,7 @@ from mcp_spotify_player.playback_controller import PlaybackController
 from mcp_spotify_player.playlist_controller import PlaylistController
 from mcp_spotify_player.spotify_client import SpotifyClient
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 TokensProvider = Callable[[], Optional[Tokens]]


### PR DESCRIPTION
## Summary
- add shared `mcp_logging` package to configure logging format, level and optional file handler
- replace scattered logging and `sys.stderr` writes with unified logger across modules
- clean up CLI and client modules to use structured logging helpers

## Testing
- `ruff check .`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a03bca2b84832c831271804a7d1eac