### PR TITLE
Add album retrieval client and controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Once authenticated, you can use these commands:
 - `search_collections` — "Search for playlists or albums"
 - `get_playlists` — "List my playlists"
 - `get_playlist_tracks` — "Show tracks in playlist 'Road Trip'"
+- `get_album` — "Show info about album 'The Dark Side of the Moon'"
 - `create_playlist` — "Create playlist 'Road Trip' with these songs..."
 - `rename_playlist` — "Rename playlist 'Road Trip' to 'Vacation'"
 - `clear_playlist` — "Remove all songs from playlist 'Road Trip'"

--- a/src/mcp_spotify_player/album_controller.py
+++ b/src/mcp_spotify_player/album_controller.py
@@ -1,7 +1,6 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from mcp_logging import get_logger
-
 from mcp_spotify_player.mcp_models import AlbumInfo
 from mcp_spotify_player.spotify_client import SpotifyClient
 

--- a/src/mcp_spotify_player/album_controller.py
+++ b/src/mcp_spotify_player/album_controller.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List
+
+from mcp_logging import get_logger
+
+from mcp_spotify_player.mcp_models import AlbumInfo
+from mcp_spotify_player.spotify_client import SpotifyClient
+
+logger = get_logger(__name__)
+
+
+class AlbumController:
+    """Controller for album-related operations using SpotifyClient."""
+
+    def __init__(self, client: SpotifyClient):
+        self.client = client
+        self.albums_client = client.albums
+
+    def get_album(self, album_id: str) -> Dict[str, Any]:
+        """Retrieve album information by ID."""
+        try:
+            if not self._validate_spotify_id(album_id):
+                return {
+                    "success": False,
+                    "message": "Invalid album ID. It must be a valid Spotify ID.",
+                }
+            album = self.albums_client.get_album(album_id)
+            if album:
+                album_info = AlbumInfo(
+                    id=album.get("id", album_id),
+                    name=album.get("name", ""),
+                    artists=[artist.get("name", "") for artist in album.get("artists", [])],
+                    release_date=album.get("release_date"),
+                    total_tracks=album.get("total_tracks", 0),
+                    uri=album.get("uri", ""),
+                )
+                return {"success": True, "album": album_info.dict()}
+            return {"success": False, "message": "Could not get album"}
+        except Exception as e:
+            return {"success": False, "message": f"Error: {str(e)}"}
+
+    def _validate_spotify_id(self, id_string: str) -> bool:
+        """Validates if the string is a valid Spotify ID"""
+        return bool(id_string) and len(id_string) > 10 and id_string.isalnum()

--- a/src/mcp_spotify_player/client_albums.py
+++ b/src/mcp_spotify_player/client_albums.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict, Optional
+
+from mcp_logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class SpotifyAlbumsClient:
+    """Client specialized in album-related operations."""
+
+    def __init__(self, requester):
+        """Initialise with an object providing ``_make_request``."""
+        self.requester = requester
+
+    def get_album(self, album_id: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a single album by its Spotify ID."""
+        logger.info("spotify_client -- Getting album with id %s", album_id)
+        result = self.requester._make_request("GET", f"/albums/{album_id}")
+        logger.debug("Response getting album by id %s: %s", album_id, result)
+        return result

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -244,6 +244,22 @@ MANIFEST = {
             }
         },
         {
+            "name": "get_album",
+            "description": "Retrieve album information by its ID",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "album_id": {
+                        "type": "string",
+                        "description": "Spotify album ID"
+                    }
+                },
+                "required": [
+                    "album_id"
+                ]
+            }
+        },
+        {
             "name": "rename_playlist",
             "description": "Rename a Spotify playlist by its ID to a new name",
             "inputSchema": {

--- a/src/mcp_spotify_player/mcp_models.py
+++ b/src/mcp_spotify_player/mcp_models.py
@@ -86,6 +86,16 @@ class PlaylistInfo(BaseModel):
             return v.get('id', 'unknown')
         return v
 
+
+class AlbumInfo(BaseModel):
+    """Album information"""
+    id: str
+    name: str
+    artists: List[str]
+    release_date: Optional[str] = None
+    total_tracks: int
+    uri: str
+
 # Models for MCP manifest
 class MCPTool(BaseModel):
     """MCP tool"""

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -67,6 +67,7 @@ class MCPServer:
             "search_collections": self.controller.playback.search_collections,
             "get_playlists": self.controller.playlists.get_playlists,
             "get_playlist_tracks": self.controller.playlists.get_playlist_tracks,
+            "get_album": self.controller.albums.get_album,
             "rename_playlist": self.controller.playlists.rename_playlist,
             "clear_playlist": self.controller.playlists.clear_playlist,
             "create_playlist": self.controller.playlists.create_playlist,
@@ -83,6 +84,7 @@ class MCPServer:
             "search_music": self._validate_search_music,
             "search_collections": self._validate_search_collections,
             "get_playlist_tracks": self._validate_get_playlist_tracks,
+            "get_album": self._validate_get_album,
             "rename_playlist": self._validate_rename_playlist,
             "clear_playlist": self._validate_clear_playlist,
             "create_playlist": self._validate_create_playlist,
@@ -99,6 +101,7 @@ class MCPServer:
             "search_collections": self._format_json_result,
             "get_playlists": self._format_json_result,
             "get_playlist_tracks": self._format_json_result,
+            "get_album": self._format_json_result,
             "queue_list": self._format_json_result,
         }
 
@@ -277,6 +280,15 @@ class MCPServer:
     def _validate_rename_playlist(self, arguments: Dict[str, Any]):
         if not arguments.get("playlist_id"):
             raise ValueError("playlist_id is required")
+
+    def _validate_get_album(self, arguments: Dict[str, Any]):
+        album_id = arguments.get("album_id")
+        if not album_id:
+            raise ValueError("album_id is required")
+        if album_id.isdigit() and len(album_id) < 10:
+            raise ValueError(
+                "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes."
+            )
 
     def _validate_clear_playlist(self, arguments: Dict[str, Any]):
         if not arguments.get("playlist_id"):

--- a/src/mcp_spotify_player/spotify_client.py
+++ b/src/mcp_spotify_player/spotify_client.py
@@ -16,6 +16,7 @@ from mcp_spotify.errors import (
 )
 from mcp_spotify_player.client_playback import SpotifyPlaybackClient
 from mcp_spotify_player.client_playlists import SpotifyPlaylistsClient
+from mcp_spotify_player.client_albums import SpotifyAlbumsClient
 from mcp_spotify_player.config import Config
 
 
@@ -36,6 +37,7 @@ class SpotifyClient:
         self.config = Config()
         self.playback = SpotifyPlaybackClient(self)
         self.playlists = SpotifyPlaylistsClient(self)
+        self.albums = SpotifyAlbumsClient(self)
         self.verify_scopes = verify_scopes
         if verify_at_startup:
             tokens = self.tokens_provider()
@@ -113,7 +115,7 @@ class SpotifyClient:
         return data
 
     def __getattr__(self, name):
-        for client in (self.playback, self.playlists):
+        for client in (self.playback, self.playlists, self.albums):
             if hasattr(client, name):
                 return getattr(client, name)
         raise AttributeError(f"{self.__class__.__name__} object has no attribute {name}")

--- a/src/mcp_spotify_player/spotify_controller.py
+++ b/src/mcp_spotify_player/spotify_controller.py
@@ -7,6 +7,7 @@ from mcp_spotify.errors import InvalidTokenFileError
 from mcp_spotify_player.client_auth import is_token_expired
 from mcp_spotify_player.playback_controller import PlaybackController
 from mcp_spotify_player.playlist_controller import PlaylistController
+from mcp_spotify_player.album_controller import AlbumController
 from mcp_spotify_player.spotify_client import SpotifyClient
 
 logger = get_logger(__name__)
@@ -23,6 +24,7 @@ class SpotifyController:
         self.client = SpotifyClient(tokens_provider)
         self.playback = PlaybackController(self.client)
         self.playlists = PlaylistController(self.client)
+        self.albums = AlbumController(self.client)
 
     def is_authenticated(self) -> bool:
         """Checks if valid authentication tokens are available."""
@@ -38,4 +40,6 @@ class SpotifyController:
             return getattr(self.playback, name)
         if hasattr(self.playlists, name):
             return getattr(self.playlists, name)
+        if hasattr(self.albums, name):
+            return getattr(self.albums, name)
         raise AttributeError(f"{self.__class__.__name__} object has no attribute {name}")

--- a/tests/test_get_album_controller.py
+++ b/tests/test_get_album_controller.py
@@ -1,0 +1,23 @@
+from mcp_spotify_player.album_controller import AlbumController
+
+
+def test_get_album_controller():
+    class DummyAlbums:
+        def get_album(self, album_id):
+            return {
+                "id": album_id,
+                "name": "Test Album",
+                "artists": [{"name": "Test Artist"}],
+                "release_date": "2024-01-01",
+                "total_tracks": 10,
+                "uri": f"spotify:album:{album_id}",
+            }
+
+    dummy_client = type("Dummy", (), {"albums": DummyAlbums()})()
+    controller = AlbumController(dummy_client)
+
+    result = controller.get_album("1234567890abc")
+    assert result["success"] is True
+    album = result["album"]
+    assert album["name"] == "Test Album"
+    assert album["artists"][0] == "Test Artist"

--- a/tests/test_get_album_manifest.py
+++ b/tests/test_get_album_manifest.py
@@ -1,0 +1,7 @@
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+
+
+def test_get_album_in_stdio_manifest():
+    server = MCPServer()
+    tool_names = [tool["name"] for tool in server.manifest["tools"]]
+    assert "get_album" in tool_names


### PR DESCRIPTION
## Summary
- add SpotifyAlbumsClient and AlbumController to fetch album info
- expose new `get_album` tool in MCP server and manifest
- cover album retrieval with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a04beb5f4c832ca26993e16c425885