### PR TITLE
feat: add support for fetching multiple albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Once authenticated, you can use these commands:
 - `get_playlists` — "List my playlists"
 - `get_playlist_tracks` — "Show tracks in playlist 'Road Trip'"
 - `get_album` — "Show info about album 'The Dark Side of the Moon'"
+- `get_albums` — "Show info about multiple albums"
 - `create_playlist` — "Create playlist 'Road Trip' with these songs..."
 - `rename_playlist` — "Rename playlist 'Road Trip' to 'Vacation'"
 - `clear_playlist` — "Remove all songs from playlist 'Road Trip'"

--- a/src/mcp_spotify_player/album_controller.py
+++ b/src/mcp_spotify_player/album_controller.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from mcp_logging import get_logger
 from mcp_spotify_player.mcp_models import AlbumInfo
@@ -34,6 +34,33 @@ class AlbumController:
                 )
                 return {"success": True, "album": album_info.dict()}
             return {"success": False, "message": "Could not get album"}
+        except Exception as e:
+            return {"success": False, "message": f"Error: {str(e)}"}
+
+    def get_albums(self, album_ids: List[str]) -> Dict[str, Any]:
+        """Retrieve information for multiple albums by their IDs."""
+        try:
+            if not album_ids or not all(self._validate_spotify_id(aid) for aid in album_ids):
+                return {
+                    "success": False,
+                    "message": "Invalid album IDs. Provide valid Spotify IDs.",
+                }
+            albums_data = self.albums_client.get_albums(album_ids)
+            if albums_data and albums_data.get("albums"):
+                albums = [
+                    AlbumInfo(
+                        id=album.get("id", ""),
+                        name=album.get("name", ""),
+                        artists=[artist.get("name", "") for artist in album.get("artists", [])],
+                        release_date=album.get("release_date"),
+                        total_tracks=album.get("total_tracks", 0),
+                        uri=album.get("uri", ""),
+                    ).dict()
+                    for album in albums_data.get("albums", [])
+                    if album
+                ]
+                return {"success": True, "albums": albums}
+            return {"success": False, "message": "Could not get albums"}
         except Exception as e:
             return {"success": False, "message": f"Error: {str(e)}"}
 

--- a/src/mcp_spotify_player/client_albums.py
+++ b/src/mcp_spotify_player/client_albums.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from mcp_logging import get_logger
 
@@ -17,4 +17,20 @@ class SpotifyAlbumsClient:
         logger.info("spotify_client -- Getting album with id %s", album_id)
         result = self.requester._make_request("GET", f"/albums/{album_id}")
         logger.debug("Response getting album by id %s: %s", album_id, result)
+        return result
+
+    def get_albums(self, album_ids: List[str]) -> Optional[Dict[str, Any]]:
+        """Retrieve multiple albums by their Spotify IDs."""
+        ids_param = ",".join(album_ids)
+        logger.info("spotify_client -- Getting albums with ids %s", ids_param)
+        result = self.requester._make_request(
+            "GET",
+            "/albums",
+            params={"ids": ids_param},
+        )
+        logger.debug(
+            "Response getting albums by ids %s: %s",
+            ids_param,
+            result,
+        )
         return result

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -260,6 +260,21 @@ MANIFEST = {
             }
         },
         {
+            "name": "get_albums",
+            "description": "Retrieve information for multiple albums by their IDs",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "album_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of Spotify album IDs"
+                    }
+                },
+                "required": ["album_ids"]
+            }
+        },
+        {
             "name": "rename_playlist",
             "description": "Rename a Spotify playlist by its ID to a new name",
             "inputSchema": {

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -68,6 +68,7 @@ class MCPServer:
             "get_playlists": self.controller.playlists.get_playlists,
             "get_playlist_tracks": self.controller.playlists.get_playlist_tracks,
             "get_album": self.controller.albums.get_album,
+            "get_albums": self.controller.albums.get_albums,
             "rename_playlist": self.controller.playlists.rename_playlist,
             "clear_playlist": self.controller.playlists.clear_playlist,
             "create_playlist": self.controller.playlists.create_playlist,
@@ -85,6 +86,7 @@ class MCPServer:
             "search_collections": self._validate_search_collections,
             "get_playlist_tracks": self._validate_get_playlist_tracks,
             "get_album": self._validate_get_album,
+            "get_albums": self._validate_get_albums,
             "rename_playlist": self._validate_rename_playlist,
             "clear_playlist": self._validate_clear_playlist,
             "create_playlist": self._validate_create_playlist,
@@ -102,6 +104,7 @@ class MCPServer:
             "get_playlists": self._format_json_result,
             "get_playlist_tracks": self._format_json_result,
             "get_album": self._format_json_result,
+            "get_albums": self._format_json_result,
             "queue_list": self._format_json_result,
         }
 
@@ -289,6 +292,16 @@ class MCPServer:
             raise ValueError(
                 "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes."
             )
+
+    def _validate_get_albums(self, arguments: Dict[str, Any]):
+        album_ids = arguments.get("album_ids")
+        if not album_ids or not isinstance(album_ids, list):
+            raise ValueError("album_ids is required")
+        for album_id in album_ids:
+            if album_id.isdigit() and len(album_id) < 10:
+                raise ValueError(
+                    "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes."
+                )
 
     def _validate_clear_playlist(self, arguments: Dict[str, Any]):
         if not arguments.get("playlist_id"):

--- a/tests/test_get_albums_controller.py
+++ b/tests/test_get_albums_controller.py
@@ -1,0 +1,29 @@
+from mcp_spotify_player.album_controller import AlbumController
+
+
+def test_get_albums_controller():
+    class DummyAlbums:
+        def get_albums(self, album_ids):
+            return {
+                "albums": [
+                    {
+                        "id": album_id,
+                        "name": f"Album {album_id}",
+                        "artists": [{"name": f"Artist {album_id}"}],
+                        "release_date": "2024-01-01",
+                        "total_tracks": 10,
+                        "uri": f"spotify:album:{album_id}",
+                    }
+                    for album_id in album_ids
+                ]
+            }
+
+    dummy_client = type("Dummy", (), {"albums": DummyAlbums()})()
+    controller = AlbumController(dummy_client)
+
+    result = controller.get_albums(["1234567890abc", "abcdef123456"])
+    assert result["success"] is True
+    albums = result["albums"]
+    assert len(albums) == 2
+    assert albums[0]["name"].startswith("Album")
+    assert albums[1]["artists"][0].startswith("Artist")

--- a/tests/test_get_albums_manifest.py
+++ b/tests/test_get_albums_manifest.py
@@ -1,0 +1,7 @@
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+
+
+def test_get_albums_in_stdio_manifest():
+    server = MCPServer()
+    tool_names = [tool["name"] for tool in server.manifest["tools"]]
+    assert "get_albums" in tool_names


### PR DESCRIPTION
## Summary
- add `get_albums` to SpotifyAlbumsClient for retrieving multiple albums
- expose `get_albums` via AlbumController and MCP server tooling
- document new `get_albums` tool and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a050002a00832c91fefec5e7ad3bb0