### PR TITLE
Add album track retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Control your Spotify music from Claude using the MCP (Model Context Protocol).
 - **Volume control**: Adjust volume from 0 to 100%
 - **Repeat mode**: Set to off, context, or track
 - **Music search**: Search for songs, artists, and albums
+- **Album browsing**: View album details and track lists
 - **Playlist management**: List, create, rename, clear, and add tracks to your playlists
 - **Integration with Claude**: Use natural commands to control your music
 
@@ -123,6 +124,7 @@ Once authenticated, you can use these commands:
 - `get_playlist_tracks` — "Show tracks in playlist 'Road Trip'"
 - `get_album` — "Show info about album 'The Dark Side of the Moon'"
 - `get_albums` — "Show info about multiple albums"
+- `get_album_tracks` — "Show tracks in album 'The Dark Side of the Moon'"
 - `create_playlist` — "Create playlist 'Road Trip' with these songs..."
 - `rename_playlist` — "Rename playlist 'Road Trip' to 'Vacation'"
 - `clear_playlist` — "Remove all songs from playlist 'Road Trip'"

--- a/src/mcp_spotify_player/client_albums.py
+++ b/src/mcp_spotify_player/client_albums.py
@@ -34,3 +34,17 @@ class SpotifyAlbumsClient:
             result,
         )
         return result
+
+    def get_album_tracks(self, album_id: str, limit: int = 20) -> Optional[Dict[str, Any]]:
+        """Retrieve tracks for a specific album."""
+        logger.info(
+            "spotify_client -- Getting tracks for album id %s", album_id
+        )
+        params = {"limit": limit}
+        result = self.requester._make_request(
+            "GET", f"/albums/{album_id}/tracks", params=params
+        )
+        logger.debug(
+            "Response getting tracks for album id %s: %s", album_id, result
+        )
+        return result

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -275,6 +275,26 @@ MANIFEST = {
             }
         },
         {
+            "name": "get_album_tracks",
+            "description": "Retrieve tracks from a given album",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "album_id": {
+                        "type": "string",
+                        "description": "Album ID"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 20
+                    }
+                },
+                "required": ["album_id"]
+            }
+        },
+        {
             "name": "rename_playlist",
             "description": "Rename a Spotify playlist by its ID to a new name",
             "inputSchema": {

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -69,6 +69,7 @@ class MCPServer:
             "get_playlist_tracks": self.controller.playlists.get_playlist_tracks,
             "get_album": self.controller.albums.get_album,
             "get_albums": self.controller.albums.get_albums,
+            "get_album_tracks": self.controller.albums.get_album_tracks,
             "rename_playlist": self.controller.playlists.rename_playlist,
             "clear_playlist": self.controller.playlists.clear_playlist,
             "create_playlist": self.controller.playlists.create_playlist,
@@ -87,6 +88,7 @@ class MCPServer:
             "get_playlist_tracks": self._validate_get_playlist_tracks,
             "get_album": self._validate_get_album,
             "get_albums": self._validate_get_albums,
+            "get_album_tracks": self._validate_get_album_tracks,
             "rename_playlist": self._validate_rename_playlist,
             "clear_playlist": self._validate_clear_playlist,
             "create_playlist": self._validate_create_playlist,
@@ -105,6 +107,7 @@ class MCPServer:
             "get_playlist_tracks": self._format_json_result,
             "get_album": self._format_json_result,
             "get_albums": self._format_json_result,
+            "get_album_tracks": self._format_json_result,
             "queue_list": self._format_json_result,
         }
 
@@ -302,6 +305,18 @@ class MCPServer:
                 raise ValueError(
                     "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes."
                 )
+
+
+
+    def _validate_get_album_tracks(self, arguments: Dict[str, Any]):
+        album_id = arguments.get("album_id")
+        if not album_id:
+            raise ValueError("album_id is required")
+        if album_id.isdigit() and len(album_id) < 10:
+            raise ValueError(
+                "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes.",
+            )
+        arguments.setdefault("limit", 20)
 
     def _validate_clear_playlist(self, arguments: Dict[str, Any]):
         if not arguments.get("playlist_id"):

--- a/tests/test_get_album_tracks_controller.py
+++ b/tests/test_get_album_tracks_controller.py
@@ -1,0 +1,27 @@
+from mcp_spotify_player.album_controller import AlbumController
+
+
+def test_get_album_tracks_controller():
+    class DummyAlbums:
+        def get_album_tracks(self, album_id, limit):
+            return {
+                "items": [
+                    {
+                        "name": "Song 1",
+                        "artists": [{"name": "Artist 1"}],
+                        "uri": f"spotify:track:{album_id}1",
+                        "duration_ms": 180000,
+                        "external_urls": {"spotify": "http://example.com"},
+                    }
+                ],
+                "total": 1,
+            }
+
+    dummy_client = type("Dummy", (), {"albums": DummyAlbums()})()
+    controller = AlbumController(dummy_client)
+
+    result = controller.get_album_tracks("1234567890abc")
+    assert result["success"] is True
+    tracks = result["tracks"]
+    assert tracks[0]["name"] == "Song 1"
+    assert tracks[0]["artist"] == "Artist 1"

--- a/tests/test_get_album_tracks_manifest.py
+++ b/tests/test_get_album_tracks_manifest.py
@@ -1,0 +1,7 @@
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+
+
+def test_get_album_tracks_in_manifest():
+    server = MCPServer()
+    tool_names = [tool["name"] for tool in server.manifest["tools"]]
+    assert "get_album_tracks" in tool_names


### PR DESCRIPTION
## Summary
- support fetching tracks from a Spotify album
- expose `get_album_tracks` tool in MCP server and manifest
- document album track retrieval in README
- add tests for new album tracks tool

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06883b394832cb5575c03fb39bd52