### PR TITLE
feat: add saved albums retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Control your Spotify music from Claude using the MCP (Model Context Protocol).
 - **Repeat mode**: Set to off, context, or track
 - **Music search**: Search for songs, artists, and albums
 - **Album browsing**: View album details and track lists
+- **Saved albums**: List albums saved in your library
 - **Playlist management**: List, create, rename, clear, and add tracks to your playlists
 - **Integration with Claude**: Use natural commands to control your music
 
@@ -125,6 +126,7 @@ Once authenticated, you can use these commands:
 - `get_album` — "Show info about album 'The Dark Side of the Moon'"
 - `get_albums` — "Show info about multiple albums"
 - `get_album_tracks` — "Show tracks in album 'The Dark Side of the Moon'"
+- `get_saved_albums` — "List my saved albums"
 - `create_playlist` — "Create playlist 'Road Trip' with these songs..."
 - `rename_playlist` — "Rename playlist 'Road Trip' to 'Vacation'"
 - `clear_playlist` — "Remove all songs from playlist 'Road Trip'"

--- a/src/mcp_spotify/auth/tokens.py
+++ b/src/mcp_spotify/auth/tokens.py
@@ -37,6 +37,9 @@ REQUIRED_SCOPES: dict[str, set[str]] = {
         "playlist-read-collaborative",
         "playlist-modify-private",
     },
+    "albums": {
+        "user-library-read",
+    },
 }
 
 

--- a/src/mcp_spotify_player/album_controller.py
+++ b/src/mcp_spotify_player/album_controller.py
@@ -95,6 +95,35 @@ class AlbumController:
         except Exception as e:
             return {"success": False, "message": f"Error: {str(e)}"}
 
+    def get_saved_albums(self, limit: int = 20) -> Dict[str, Any]:
+        """Retrieve albums saved in the user's library."""
+        try:
+            saved = self.albums_client.get_saved_albums(limit)
+            if saved and saved.get("items"):
+                albums = []
+                for item in saved.get("items", []):
+                    album = item.get("album")
+                    if not album:
+                        continue
+                    album_info = AlbumInfo(
+                        id=album.get("id", ""),
+                        name=album.get("name", ""),
+                        artists=[artist.get("name", "") for artist in album.get("artists", [])],
+                        release_date=album.get("release_date"),
+                        total_tracks=album.get("total_tracks", 0),
+                        uri=album.get("uri", ""),
+                    )
+                    albums.append(album_info.dict())
+
+                return {
+                    "success": True,
+                    "albums": albums,
+                    "total_albums": saved.get("total", 0),
+                }
+            return {"success": False, "message": "Could not get saved albums"}
+        except Exception as e:
+            return {"success": False, "message": f"Error: {str(e)}"}
+
     def _validate_spotify_id(self, id_string: str) -> bool:
         """Validates if the string is a valid Spotify ID"""
         return bool(id_string) and len(id_string) > 10 and id_string.isalnum()

--- a/src/mcp_spotify_player/client_albums.py
+++ b/src/mcp_spotify_player/client_albums.py
@@ -48,3 +48,18 @@ class SpotifyAlbumsClient:
             "Response getting tracks for album id %s: %s", album_id, result
         )
         return result
+
+    def get_saved_albums(self, limit: int = 20) -> Optional[Dict[str, Any]]:
+        """Retrieve albums saved in the user's library."""
+        params = {"limit": limit}
+        logger.info(
+            "spotify_client -- Getting user saved albums with limit %s", limit
+        )
+        result = self.requester._make_request(
+            "GET",
+            "/me/albums",
+            feature="albums",
+            params=params,
+        )
+        logger.debug("Response getting user saved albums: %s", result)
+        return result

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -295,6 +295,21 @@ MANIFEST = {
             }
         },
         {
+            "name": "get_saved_albums",
+            "description": "Retrieve the user's saved albums",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50,
+                        "default": 20
+                    }
+                }
+            }
+        },
+        {
             "name": "rename_playlist",
             "description": "Rename a Spotify playlist by its ID to a new name",
             "inputSchema": {

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -70,6 +70,7 @@ class MCPServer:
             "get_album": self.controller.albums.get_album,
             "get_albums": self.controller.albums.get_albums,
             "get_album_tracks": self.controller.albums.get_album_tracks,
+            "get_saved_albums": self.controller.albums.get_saved_albums,
             "rename_playlist": self.controller.playlists.rename_playlist,
             "clear_playlist": self.controller.playlists.clear_playlist,
             "create_playlist": self.controller.playlists.create_playlist,
@@ -89,6 +90,7 @@ class MCPServer:
             "get_album": self._validate_get_album,
             "get_albums": self._validate_get_albums,
             "get_album_tracks": self._validate_get_album_tracks,
+            "get_saved_albums": self._validate_get_saved_albums,
             "rename_playlist": self._validate_rename_playlist,
             "clear_playlist": self._validate_clear_playlist,
             "create_playlist": self._validate_create_playlist,
@@ -108,6 +110,7 @@ class MCPServer:
             "get_album": self._format_json_result,
             "get_albums": self._format_json_result,
             "get_album_tracks": self._format_json_result,
+            "get_saved_albums": self._format_json_result,
             "queue_list": self._format_json_result,
         }
 
@@ -317,6 +320,14 @@ class MCPServer:
                 "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes.",
             )
         arguments.setdefault("limit", 20)
+
+    def _validate_get_saved_albums(self, arguments: Dict[str, Any]):
+        limit = arguments.get("limit")
+        if limit is not None:
+            if not isinstance(limit, int) or limit < 1 or limit > 50:
+                raise ValueError("limit must be between 1 and 50")
+        else:
+            arguments["limit"] = 20
 
     def _validate_clear_playlist(self, arguments: Dict[str, Any]):
         if not arguments.get("playlist_id"):

--- a/tests/test_get_saved_albums_controller.py
+++ b/tests/test_get_saved_albums_controller.py
@@ -1,0 +1,30 @@
+from mcp_spotify_player.album_controller import AlbumController
+
+
+def test_get_saved_albums_controller():
+    class DummyAlbums:
+        def get_saved_albums(self, limit):
+            return {
+                "items": [
+                    {
+                        "album": {
+                            "id": "abc123",
+                            "name": "Album 1",
+                            "artists": [{"name": "Artist 1"}],
+                            "release_date": "2024-01-01",
+                            "total_tracks": 10,
+                            "uri": "spotify:album:abc123",
+                        }
+                    }
+                ],
+                "total": 1,
+            }
+
+    dummy_client = type("Dummy", (), {"albums": DummyAlbums()})()
+    controller = AlbumController(dummy_client)
+
+    result = controller.get_saved_albums()
+    assert result["success"] is True
+    albums = result["albums"]
+    assert len(albums) == 1
+    assert albums[0]["name"] == "Album 1"

--- a/tests/test_get_saved_albums_manifest.py
+++ b/tests/test_get_saved_albums_manifest.py
@@ -1,0 +1,7 @@
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+
+
+def test_get_saved_albums_in_manifest():
+    server = MCPServer()
+    tool_names = [tool["name"] for tool in server.manifest["tools"]]
+    assert "get_saved_albums" in tool_names


### PR DESCRIPTION
## Summary
- support retrieving a user's saved albums via Spotify API
- expose new `get_saved_albums` tool with validation and logging
- document saved albums command in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a071f0d098832ca0ac4f7716981d9e