### PR TITLE
feat: add ability to save albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Control your Spotify music from Claude using the MCP (Model Context Protocol).
 - **Music search**: Search for songs, artists, and albums
 - **Album browsing**: View album details and track lists
 - **Saved albums**: List albums saved in your library
+- **Save albums**: Add albums to your library
 - **Playlist management**: List, create, rename, clear, and add tracks to your playlists
 - **Integration with Claude**: Use natural commands to control your music
 
@@ -127,6 +128,7 @@ Once authenticated, you can use these commands:
 - `get_albums` — "Show info about multiple albums"
 - `get_album_tracks` — "Show tracks in album 'The Dark Side of the Moon'"
 - `get_saved_albums` — "List my saved albums"
+- `save_albums` — "Save these albums to my library"
 - `create_playlist` — "Create playlist 'Road Trip' with these songs..."
 - `rename_playlist` — "Rename playlist 'Road Trip' to 'Vacation'"
 - `clear_playlist` — "Remove all songs from playlist 'Road Trip'"

--- a/src/mcp_spotify_player/album_controller.py
+++ b/src/mcp_spotify_player/album_controller.py
@@ -124,6 +124,21 @@ class AlbumController:
         except Exception as e:
             return {"success": False, "message": f"Error: {str(e)}"}
 
+    def save_albums(self, album_ids: List[str]) -> Dict[str, Any]:
+        """Save albums to the user's library."""
+        try:
+            if not album_ids or not all(self._validate_spotify_id(aid) for aid in album_ids):
+                return {
+                    "success": False,
+                    "message": "Invalid album IDs. Provide valid Spotify IDs.",
+                }
+            result = self.albums_client.save_albums(album_ids)
+            if result:
+                return {"success": True, "message": "Albums saved successfully"}
+            return {"success": False, "message": "Could not save albums"}
+        except Exception as e:
+            return {"success": False, "message": f"Error: {str(e)}"}
+
     def _validate_spotify_id(self, id_string: str) -> bool:
         """Validates if the string is a valid Spotify ID"""
         return bool(id_string) and len(id_string) > 10 and id_string.isalnum()

--- a/src/mcp_spotify_player/client_albums.py
+++ b/src/mcp_spotify_player/client_albums.py
@@ -63,3 +63,18 @@ class SpotifyAlbumsClient:
         )
         logger.debug("Response getting user saved albums: %s", result)
         return result
+
+    def save_albums(self, album_ids: List[str]) -> bool:
+        """Save one or more albums to the user's library."""
+        ids_param = ",".join(album_ids)
+        logger.info(
+            "spotify_client -- Saving albums with ids %s", ids_param
+        )
+        result = self.requester._make_request(
+            "PUT",
+            "/me/albums",
+            feature="albums",
+            json={"ids": album_ids},
+        )
+        logger.debug("Response saving albums %s: %s", ids_param, result)
+        return result is not None

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -310,6 +310,21 @@ MANIFEST = {
             }
         },
         {
+            "name": "save_albums",
+            "description": "Save one or more albums to the user's library",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "album_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of Spotify album IDs"
+                    }
+                },
+                "required": ["album_ids"]
+            }
+        },
+        {
             "name": "rename_playlist",
             "description": "Rename a Spotify playlist by its ID to a new name",
             "inputSchema": {

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -71,6 +71,7 @@ class MCPServer:
             "get_albums": self.controller.albums.get_albums,
             "get_album_tracks": self.controller.albums.get_album_tracks,
             "get_saved_albums": self.controller.albums.get_saved_albums,
+            "save_albums": self.controller.albums.save_albums,
             "rename_playlist": self.controller.playlists.rename_playlist,
             "clear_playlist": self.controller.playlists.clear_playlist,
             "create_playlist": self.controller.playlists.create_playlist,
@@ -91,6 +92,7 @@ class MCPServer:
             "get_albums": self._validate_get_albums,
             "get_album_tracks": self._validate_get_album_tracks,
             "get_saved_albums": self._validate_get_saved_albums,
+            "save_albums": self._validate_save_albums,
             "rename_playlist": self._validate_rename_playlist,
             "clear_playlist": self._validate_clear_playlist,
             "create_playlist": self._validate_create_playlist,
@@ -111,6 +113,7 @@ class MCPServer:
             "get_albums": self._format_json_result,
             "get_album_tracks": self._format_json_result,
             "get_saved_albums": self._format_json_result,
+            "save_albums": self._format_json_result,
             "queue_list": self._format_json_result,
         }
 
@@ -328,6 +331,16 @@ class MCPServer:
                 raise ValueError("limit must be between 1 and 50")
         else:
             arguments["limit"] = 20
+
+    def _validate_save_albums(self, arguments: Dict[str, Any]):
+        album_ids = arguments.get("album_ids")
+        if not album_ids or not isinstance(album_ids, list):
+            raise ValueError("album_ids is required")
+        for album_id in album_ids:
+            if album_id.isdigit() and len(album_id) < 10:
+                raise ValueError(
+                    "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes."
+                )
 
     def _validate_clear_playlist(self, arguments: Dict[str, Any]):
         if not arguments.get("playlist_id"):

--- a/tests/test_save_albums.py
+++ b/tests/test_save_albums.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch
+
+from mcp_spotify_player.spotify_client import SpotifyClient
+from mcp_spotify_player.spotify_controller import SpotifyController
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+
+
+def test_spotify_client_save_albums():
+    client = SpotifyClient()
+    with patch.object(client, "_make_request", return_value=True) as mock_request:
+        assert client.save_albums(["album1", "album2"]) is True
+        mock_request.assert_called_once_with(
+            "PUT",
+            "/me/albums",
+            feature="albums",
+            json={"ids": ["album1", "album2"]},
+        )
+
+
+def test_album_controller_save_albums():
+    controller = SpotifyController(lambda: None)
+    with patch.object(
+        controller.albums_client, "save_albums", return_value=True
+    ) as mock_save:
+        result = controller.save_albums(["1234567890a"])
+        assert result["success"] is True
+        mock_save.assert_called_once_with(["1234567890a"])
+
+
+def test_album_controller_save_albums_invalid():
+    controller = SpotifyController(lambda: None)
+    result = controller.save_albums(["bad id!"])
+    assert result["success"] is False
+
+
+def test_mcp_server_save_albums():
+    server = MCPServer()
+    assert any(tool["name"] == "save_albums" for tool in server.manifest["tools"])
+    with patch.object(
+        server.controller,
+        "save_albums",
+        return_value={"success": True, "message": "Albums saved successfully"},
+    ) as mock_save:
+        server.TOOL_HANDLERS["save_albums"] = server.controller.save_albums
+        result = server.execute_tool("save_albums", {"album_ids": ["1234567890a"]})
+        assert "saved" in result.lower()
+        mock_save.assert_called_once_with(album_ids=["1234567890a"])
+


### PR DESCRIPTION
## Summary
- add client, controller and server support to save albums to the user library
- expose new `save_albums` tool in the MCP manifest and stdio server
- document and test album-saving feature

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0748009bc832c95152fa779eda24b