### PR TITLE
feat: add delete saved albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Control your Spotify music from Claude using the MCP (Model Context Protocol).
 - **Album browsing**: View album details and track lists
 - **Saved albums**: List albums saved in your library
 - **Save albums**: Add albums to your library
+- **Delete saved albums**: Remove albums from your library
 - **Playlist management**: List, create, rename, clear, and add tracks to your playlists
 - **Integration with Claude**: Use natural commands to control your music
 
@@ -129,6 +130,7 @@ Once authenticated, you can use these commands:
 - `get_album_tracks` — "Show tracks in album 'The Dark Side of the Moon'"
 - `get_saved_albums` — "List my saved albums"
 - `save_albums` — "Save these albums to my library"
+- `delete_saved_albums` — "Remove these albums from my library"
 - `create_playlist` — "Create playlist 'Road Trip' with these songs..."
 - `rename_playlist` — "Rename playlist 'Road Trip' to 'Vacation'"
 - `clear_playlist` — "Remove all songs from playlist 'Road Trip'"

--- a/src/mcp_spotify_player/album_controller.py
+++ b/src/mcp_spotify_player/album_controller.py
@@ -139,6 +139,21 @@ class AlbumController:
         except Exception as e:
             return {"success": False, "message": f"Error: {str(e)}"}
 
+    def delete_saved_albums(self, album_ids: List[str]) -> Dict[str, Any]:
+        """Remove albums from the user's library."""
+        try:
+            if not album_ids or not all(self._validate_spotify_id(aid) for aid in album_ids):
+                return {
+                    "success": False,
+                    "message": "Invalid album IDs. Provide valid Spotify IDs.",
+                }
+            result = self.albums_client.delete_saved_albums(album_ids)
+            if result:
+                return {"success": True, "message": "Albums deleted successfully"}
+            return {"success": False, "message": "Could not delete albums"}
+        except Exception as e:
+            return {"success": False, "message": f"Error: {str(e)}"}
+
     def _validate_spotify_id(self, id_string: str) -> bool:
         """Validates if the string is a valid Spotify ID"""
         return bool(id_string) and len(id_string) > 10 and id_string.isalnum()

--- a/src/mcp_spotify_player/client_albums.py
+++ b/src/mcp_spotify_player/client_albums.py
@@ -78,3 +78,18 @@ class SpotifyAlbumsClient:
         )
         logger.debug("Response saving albums %s: %s", ids_param, result)
         return result is not None
+
+    def delete_saved_albums(self, album_ids: List[str]) -> bool:
+        """Remove one or more albums from the user's library."""
+        ids_param = ",".join(album_ids)
+        logger.info(
+            "spotify_client -- Deleting albums with ids %s", ids_param
+        )
+        result = self.requester._make_request(
+            "DELETE",
+            "/me/albums",
+            feature="albums",
+            json={"ids": album_ids},
+        )
+        logger.debug("Response deleting albums %s: %s", ids_param, result)
+        return result is not None

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -325,6 +325,21 @@ MANIFEST = {
             }
         },
         {
+            "name": "delete_saved_albums",
+            "description": "Remove one or more albums from the user's library",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "album_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of Spotify album IDs"
+                    }
+                },
+                "required": ["album_ids"]
+            }
+        },
+        {
             "name": "rename_playlist",
             "description": "Rename a Spotify playlist by its ID to a new name",
             "inputSchema": {

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -72,6 +72,7 @@ class MCPServer:
             "get_album_tracks": self.controller.albums.get_album_tracks,
             "get_saved_albums": self.controller.albums.get_saved_albums,
             "save_albums": self.controller.albums.save_albums,
+            "delete_saved_albums": self.controller.albums.delete_saved_albums,
             "rename_playlist": self.controller.playlists.rename_playlist,
             "clear_playlist": self.controller.playlists.clear_playlist,
             "create_playlist": self.controller.playlists.create_playlist,
@@ -93,6 +94,7 @@ class MCPServer:
             "get_album_tracks": self._validate_get_album_tracks,
             "get_saved_albums": self._validate_get_saved_albums,
             "save_albums": self._validate_save_albums,
+            "delete_saved_albums": self._validate_delete_saved_albums,
             "rename_playlist": self._validate_rename_playlist,
             "clear_playlist": self._validate_clear_playlist,
             "create_playlist": self._validate_create_playlist,
@@ -114,6 +116,7 @@ class MCPServer:
             "get_album_tracks": self._format_json_result,
             "get_saved_albums": self._format_json_result,
             "save_albums": self._format_json_result,
+            "delete_saved_albums": self._format_json_result,
             "queue_list": self._format_json_result,
         }
 
@@ -333,6 +336,16 @@ class MCPServer:
             arguments["limit"] = 20
 
     def _validate_save_albums(self, arguments: Dict[str, Any]):
+        album_ids = arguments.get("album_ids")
+        if not album_ids or not isinstance(album_ids, list):
+            raise ValueError("album_ids is required")
+        for album_id in album_ids:
+            if album_id.isdigit() and len(album_id) < 10:
+                raise ValueError(
+                    "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes."
+                )
+
+    def _validate_delete_saved_albums(self, arguments: Dict[str, Any]):
         album_ids = arguments.get("album_ids")
         if not album_ids or not isinstance(album_ids, list):
             raise ValueError("album_ids is required")

--- a/tests/test_delete_saved_albums.py
+++ b/tests/test_delete_saved_albums.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+
+from unittest.mock import patch
+
+from mcp_spotify_player.spotify_client import SpotifyClient
+from mcp_spotify_player.spotify_controller import SpotifyController
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+
+
+def test_spotify_client_delete_saved_albums():
+    client = SpotifyClient()
+    with patch.object(client, "_make_request", return_value=True) as mock_request:
+        assert client.delete_saved_albums(["album1", "album2"]) is True
+        mock_request.assert_called_once_with(
+            "DELETE",
+            "/me/albums",
+            feature="albums",
+            json={"ids": ["album1", "album2"]},
+        )
+
+
+def test_album_controller_delete_saved_albums():
+    controller = SpotifyController(lambda: None)
+    with patch.object(
+        controller.albums_client, "delete_saved_albums", return_value=True
+    ) as mock_delete:
+        result = controller.delete_saved_albums(["1234567890a"])
+        assert result["success"] is True
+        mock_delete.assert_called_once_with(["1234567890a"])
+
+
+def test_album_controller_delete_saved_albums_invalid():
+    controller = SpotifyController(lambda: None)
+    result = controller.delete_saved_albums(["bad id!"])
+    assert result["success"] is False
+
+
+def test_mcp_server_delete_saved_albums():
+    server = MCPServer()
+    assert any(
+        tool["name"] == "delete_saved_albums" for tool in server.manifest["tools"]
+    )
+    with patch.object(
+        server.controller,
+        "delete_saved_albums",
+        return_value={"success": True, "message": "Albums deleted successfully"},
+    ) as mock_delete:
+        server.TOOL_HANDLERS["delete_saved_albums"] = server.controller.delete_saved_albums
+        result = server.execute_tool(
+            "delete_saved_albums", {"album_ids": ["1234567890a"]}
+        )
+        assert "deleted" in result.lower()
+        mock_delete.assert_called_once_with(album_ids=["1234567890a"])


### PR DESCRIPTION
## Summary
- support deleting saved albums via Spotify API
- expose delete_saved_albums tool and server wiring
- document delete_saved_albums usage and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0780c6f2c832ca392a210112285b3