### PR TITLE
feat: add saved album check

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Control your Spotify music from Claude using the MCP (Model Context Protocol).
 - **Music search**: Search for songs, artists, and albums
 - **Album browsing**: View album details and track lists
 - **Saved albums**: List albums saved in your library
+- **Check saved albums**: Verify if albums are in your library
 - **Save albums**: Add albums to your library
 - **Delete saved albums**: Remove albums from your library
 - **Playlist management**: List, create, rename, clear, and add tracks to your playlists
@@ -129,6 +130,7 @@ Once authenticated, you can use these commands:
 - `get_albums` — "Show info about multiple albums"
 - `get_album_tracks` — "Show tracks in album 'The Dark Side of the Moon'"
 - `get_saved_albums` — "List my saved albums"
+- `check_saved_albums` — "Check if these albums are saved"
 - `save_albums` — "Save these albums to my library"
 - `delete_saved_albums` — "Remove these albums from my library"
 - `create_playlist` — "Create playlist 'Road Trip' with these songs..."

--- a/src/mcp_spotify_player/album_controller.py
+++ b/src/mcp_spotify_player/album_controller.py
@@ -124,6 +124,25 @@ class AlbumController:
         except Exception as e:
             return {"success": False, "message": f"Error: {str(e)}"}
 
+    def check_saved_albums(self, album_ids: List[str]) -> Dict[str, Any]:
+        """Check if the specified albums are saved in the user's library."""
+        try:
+            if not album_ids or not all(self._validate_spotify_id(aid) for aid in album_ids):
+                return {
+                    "success": False,
+                    "message": "Invalid album IDs. Provide valid Spotify IDs.",
+                }
+            result = self.albums_client.check_saved_albums(album_ids)
+            if result is not None:
+                albums = [
+                    {"id": aid, "saved": saved}
+                    for aid, saved in zip(album_ids, result)
+                ]
+                return {"success": True, "albums": albums}
+            return {"success": False, "message": "Could not check saved albums"}
+        except Exception as e:
+            return {"success": False, "message": f"Error: {str(e)}"}
+
     def save_albums(self, album_ids: List[str]) -> Dict[str, Any]:
         """Save albums to the user's library."""
         try:

--- a/src/mcp_spotify_player/client_albums.py
+++ b/src/mcp_spotify_player/client_albums.py
@@ -64,6 +64,23 @@ class SpotifyAlbumsClient:
         logger.debug("Response getting user saved albums: %s", result)
         return result
 
+    def check_saved_albums(self, album_ids: List[str]) -> Optional[List[bool]]:
+        """Check if the specified albums are saved in the user's library."""
+        ids_param = ",".join(album_ids)
+        logger.info(
+            "spotify_client -- Checking if albums are saved with ids %s", ids_param
+        )
+        result = self.requester._make_request(
+            "GET",
+            "/me/albums/contains",
+            feature="albums",
+            params={"ids": ids_param},
+        )
+        logger.debug(
+            "Response checking if albums %s are saved: %s", ids_param, result
+        )
+        return result
+
     def save_albums(self, album_ids: List[str]) -> bool:
         """Save one or more albums to the user's library."""
         ids_param = ",".join(album_ids)

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -310,6 +310,21 @@ MANIFEST = {
             }
         },
         {
+            "name": "check_saved_albums",
+            "description": "Check if the specified albums are saved in the user's library",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "album_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of Spotify album IDs"
+                    }
+                },
+                "required": ["album_ids"]
+            }
+        },
+        {
             "name": "save_albums",
             "description": "Save one or more albums to the user's library",
             "inputSchema": {

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -71,6 +71,7 @@ class MCPServer:
             "get_albums": self.controller.albums.get_albums,
             "get_album_tracks": self.controller.albums.get_album_tracks,
             "get_saved_albums": self.controller.albums.get_saved_albums,
+            "check_saved_albums": self.controller.albums.check_saved_albums,
             "save_albums": self.controller.albums.save_albums,
             "delete_saved_albums": self.controller.albums.delete_saved_albums,
             "rename_playlist": self.controller.playlists.rename_playlist,
@@ -93,6 +94,7 @@ class MCPServer:
             "get_albums": self._validate_get_albums,
             "get_album_tracks": self._validate_get_album_tracks,
             "get_saved_albums": self._validate_get_saved_albums,
+            "check_saved_albums": self._validate_check_saved_albums,
             "save_albums": self._validate_save_albums,
             "delete_saved_albums": self._validate_delete_saved_albums,
             "rename_playlist": self._validate_rename_playlist,
@@ -115,6 +117,7 @@ class MCPServer:
             "get_albums": self._format_json_result,
             "get_album_tracks": self._format_json_result,
             "get_saved_albums": self._format_json_result,
+            "check_saved_albums": self._format_json_result,
             "save_albums": self._format_json_result,
             "delete_saved_albums": self._format_json_result,
             "queue_list": self._format_json_result,
@@ -334,6 +337,16 @@ class MCPServer:
                 raise ValueError("limit must be between 1 and 50")
         else:
             arguments["limit"] = 20
+
+    def _validate_check_saved_albums(self, arguments: Dict[str, Any]):
+        album_ids = arguments.get("album_ids")
+        if not album_ids or not isinstance(album_ids, list):
+            raise ValueError("album_ids is required")
+        for album_id in album_ids:
+            if album_id.isdigit() and len(album_id) < 10:
+                raise ValueError(
+                    "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes."
+                )
 
     def _validate_save_albums(self, arguments: Dict[str, Any]):
         album_ids = arguments.get("album_ids")

--- a/tests/test_check_saved_albums_controller.py
+++ b/tests/test_check_saved_albums_controller.py
@@ -1,0 +1,17 @@
+from mcp_spotify_player.album_controller import AlbumController
+
+
+def test_check_saved_albums_controller():
+    class DummyAlbums:
+        def check_saved_albums(self, album_ids):
+            return [True, False]
+
+    dummy_client = type("Dummy", (), {"albums": DummyAlbums()})()
+    controller = AlbumController(dummy_client)
+
+    result = controller.check_saved_albums(["abc123def456", "def456abc789"])
+    assert result["success"] is True
+    assert result["albums"] == [
+        {"id": "abc123def456", "saved": True},
+        {"id": "def456abc789", "saved": False},
+    ]

--- a/tests/test_check_saved_albums_manifest.py
+++ b/tests/test_check_saved_albums_manifest.py
@@ -1,0 +1,7 @@
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+
+
+def test_check_saved_albums_in_manifest():
+    server = MCPServer()
+    tool_names = [tool["name"] for tool in server.manifest["tools"]]
+    assert "check_saved_albums" in tool_names


### PR DESCRIPTION
## Summary
- add client and controller support to verify if albums are saved
- expose checkSavedAlbums tool through MCP server and manifest
- document check_saved_albums usage and add tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07a5108f8832c8f01fcc36b65cd65