### PR TITLE
fix: update configuration docs

### DIFF
--- a/CLAUDE_INTEGRATION.md
+++ b/CLAUDE_INTEGRATION.md
@@ -11,6 +11,7 @@
 4. **IMPORTANT:** Edit the file and change:
    - `"tu_client_id_aqui"` to your actual CLIENT_ID
    - `"tu_client_secret_aqui"` to your actual CLIENT_SECRET
+   - `"path_to_your_python"` to your Python interpreter path
    - `"Z:/projects/mcp/mcp-spotify-player"` to your actual path
 
 **Option B - Other MCP clients:**
@@ -23,7 +24,7 @@ Before integrating with Claude, make sure the server is running:
 
 ```bash
 # In your terminal, from the project folder:
-python start_mcp_server.py
+python -m mcp_spotify_player
 ```
 
 ### 3. **Authenticate with Spotify**
@@ -48,8 +49,8 @@ Once configured, you can say to Claude:
 {
   "mcpServers": {
     "spotify-player": {
-      "command": "python",
-      "args": ["start_mcp_server.py"],
+      "command": "path_to_your_python",
+      "args": ["-m", "mcp_spotify_player"],
       "env": {
         "SPOTIFY_CLIENT_ID": "your_actual_client_id",
         "SPOTIFY_CLIENT_SECRET": "your_actual_client_secret",
@@ -66,9 +67,10 @@ Once configured, you can say to Claude:
 ```yaml
 mcpServers:
   spotify-player:
-    command: python
+    command: path_to_your_python
     args:
-      - start_mcp_server.py
+      - -m
+      - mcp_spotify_player
     env:
       SPOTIFY_CLIENT_ID: "your_actual_client_id"
       SPOTIFY_CLIENT_SECRET: "your_actual_client_secret"
@@ -97,19 +99,19 @@ Once integrated, Claude can use these commands:
 ## 🔧 Available server types
 
 ### MCP stdio server (Recommended for Claude)
-- **File**: `start_mcp_server.py`
+- **Command**: `python -m mcp_spotify_player`
 - **Protocol**: JSON-RPC over stdio
 - **Usage**: Direct integration with MCP-compatible clients
 - **Communication**: Direct, no HTTP
 
-**Note**: For integration with Claude, always use the MCP stdio server (`start_mcp_server.py`).
+**Note**: For integration with Claude, always use the MCP stdio server (`python -m mcp_spotify_player`).
 
 ## 🐛 Troubleshooting
 
 ### Error: "Server not found" or timeout
-- Check the server is running with `python start_mcp_server.py`
+- Check the server is running with `python -m mcp_spotify_player`
 - Make sure the path in `cwd` is correct
-- Ensure environment variables are set in the `env` file
+- Ensure environment variables are set in the `.env` file
 
 ### Error: "Authentication required"
 - Run the `/auth` command to authenticate
@@ -120,7 +122,7 @@ Once integrated, Claude can use these commands:
 
 ### Timeout error
 If you see `McpError: MCP error -32001: Request timed out`:
-1. Verify you are using `start_mcp_server.py` in your MCP configuration
+1. Verify you are using `python -m mcp_spotify_player` in your MCP configuration
 2. Restart the client after changing the configuration
 3. Ensure environment variables are set
 
@@ -130,6 +132,6 @@ If you see `McpError: MCP error -32001: Request timed out`:
 ## 📞 Support
 
 If you have issues:
-1. Verify the server runs manually with `python start_mcp_server.py`
+1. Verify the server runs manually with `python -m mcp_spotify_player`
 2. Check the server logs
 3. Review the Spotify Developer Dashboard configuration

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,7 +67,7 @@ SPOTIFY_REDIRECT_URI=http://localhost:8000/auth/callback
 
 1. **Install dependencies**: `pip install -r requirements.txt`
 2. **Configure credentials**: Edit `.env` with your Spotify details
-3. **Start server**: `python start_mcp_server.py`
+3. **Start server**: `mcp-spotify-player`
 
 ## 🎵 Example Usage with Claude
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ pip install -e .
 3. **Set up environment variables**:
 
 ```bash
-cp env.example env
+cp env.example .env
 ```
 
-Edit the `env` file with your Spotify credentials:
+Edit the `.env` file with your Spotify credentials:
 
 ```env
    SPOTIFY_CLIENT_ID=your_client_id_here
@@ -207,7 +207,7 @@ McpError: MCP error -32001: Request timed out
 If you see "Not authenticated with Spotify":
 
 1. Run the `/auth` command in your MCP client
-2. Verify that the credentials in `env` are correct
+2. Verify that the credentials in `.env` are correct
 
 ### Browser not responding
 

--- a/env.example
+++ b/env.example
@@ -3,10 +3,14 @@
 # ========================================
 
 # Spotify API Configuration
-# You cand obtains these credentials in  https://developer.spotify.com/dashboard
+# You can obtain these credentials at https://developer.spotify.com/dashboard
 SPOTIFY_CLIENT_ID=your_spotify_client_id_here
 SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here
 SPOTIFY_REDIRECT_URI=http://127.0.0.1:8000/auth/callback
+
+# Optional: custom path to store OAuth tokens
+# Defaults to ~/.config/mcp_spotify_player/tokens.json
+# MCP_SPOTIFY_TOKENS_PATH=/path/to/tokens.json
 
 # Server Configuration
 PORT=8000

--- a/mcp-spotify-player.yaml
+++ b/mcp-spotify-player.yaml
@@ -4,8 +4,10 @@
 
 mcpServers:
   spotify-player:
-    command: mcp-spotify-player
-    args: []
+    command: path_to_your_python
+    args:
+      - -m
+      - mcp_spotify_player
     env:
       # Make sure these variables are set
       SPOTIFY_CLIENT_ID: "your_client_id_here"


### PR DESCRIPTION
## Summary
- generalize Python path in Claude integration guide
- update example YAML config to invoke module via `-m mcp_spotify_player`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a2899a60832cb5f8479a6ab4a5b0