### PR TITLE
Add artist lookup endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Control your Spotify music from Claude using the MCP (Model Context Protocol).
 - **Music search**: Search for songs, artists, and albums
 - **Collection search**: Find public playlists or albums
 - **Album browsing**: View album details and track lists
+- **Artist info**: View artist details by ID
 - **Saved albums**: List albums saved in your library
 - **Check saved albums**: Verify if albums are in your library
 - **Save albums**: Add albums to your library
@@ -105,6 +106,7 @@ After authenticating with Spotify, you can use these commands in your MCP client
 - `search_collections` — "Search for playlists or albums"
 - `get_playlists` — "List my playlists"
 - `get_playlist_tracks` — "Show tracks in playlist 'Road Trip'"
+- `get_artist` — "Show info about artist with a given ID"
 - `get_album` — "Show info about album 'The Dark Side of the Moon'"
 - `get_albums` — "Show info about multiple albums"
 - `get_album_tracks` — "Show tracks in album 'The Dark Side of the Moon'"
@@ -160,12 +162,14 @@ mcp-spotify-player/
 │       ├── client_auth.py
 │       ├── client_playback.py
 │       ├── client_playlists.py
+│       ├── client_artists.py
 │       ├── config.py
 │       ├── mcp_manifest.py
 │       ├── mcp_models.py
 │       ├── mcp_stdio_server.py
 │       ├── playback_controller.py
 │       ├── playlist_controller.py
+│       ├── artists_controller.py
 │       ├── spotify_client.py
 │       └── spotify_controller.py
 ├── pyproject.toml

--- a/src/mcp_spotify_player/artists_controller.py
+++ b/src/mcp_spotify_player/artists_controller.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict
+
+from mcp_logging import get_logger
+from mcp_spotify_player.mcp_models import ArtistInfo
+from mcp_spotify_player.spotify_client import SpotifyClient
+
+logger = get_logger(__name__)
+
+
+class ArtistsController:
+    """Controller for artist-related operations using SpotifyClient."""
+
+    def __init__(self, client: SpotifyClient):
+        self.client = client
+        self.artists_client = client.artists
+
+    def get_artist(self, artist_id: str) -> Dict[str, Any]:
+        """Retrieve artist information by ID."""
+        logger.info("artists_controller -- Getting artist with id %s", artist_id)
+        try:
+            if not self._validate_spotify_id(artist_id):
+                return {
+                    "success": False,
+                    "message": "Invalid artist ID. It must be a valid Spotify ID.",
+                }
+            artist = self.artists_client.get_artist(artist_id)
+            if artist:
+                artist_info = ArtistInfo(
+                    id=artist.get("id", artist_id),
+                    name=artist.get("name", ""),
+                    genres=artist.get("genres", []),
+                    followers=artist.get("followers", {}).get("total", 0),
+                    popularity=artist.get("popularity", 0),
+                    uri=artist.get("uri", ""),
+                )
+                return {"success": True, "artist": artist_info.dict()}
+            return {"success": False, "message": "Could not get artist"}
+        except Exception as e:
+            logger.error("Error retrieving artist %s: %s", artist_id, e)
+            return {"success": False, "message": f"Error: {str(e)}"}
+
+    def _validate_spotify_id(self, id_string: str) -> bool:
+        """Validates if the string is a valid Spotify ID"""
+        return bool(id_string) and len(id_string) > 10 and id_string.isalnum()

--- a/src/mcp_spotify_player/client_artists.py
+++ b/src/mcp_spotify_player/client_artists.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict, Optional
+
+from mcp_logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class SpotifyArtistsClient:
+    """Client specialized in artist-related operations."""
+
+    def __init__(self, requester):
+        """Initialise with an object providing ``_make_request``."""
+        self.requester = requester
+
+    def get_artist(self, artist_id: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a single artist by its Spotify ID."""
+        logger.info("spotify_client -- Getting artist with id %s", artist_id)
+        result = self.requester._make_request("GET", f"/artists/{artist_id}")
+        logger.debug("Response getting artist by id %s: %s", artist_id, result)
+        return result

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -244,6 +244,20 @@ MANIFEST = {
             }
         },
         {
+            "name": "get_artist",
+            "description": "Retrieve artist information by its ID",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "artist_id": {
+                        "type": "string",
+                        "description": "Spotify artist ID",
+                    }
+                },
+                "required": ["artist_id"],
+            },
+        },
+        {
             "name": "get_album",
             "description": "Retrieve album information by its ID",
             "inputSchema": {

--- a/src/mcp_spotify_player/mcp_models.py
+++ b/src/mcp_spotify_player/mcp_models.py
@@ -96,6 +96,16 @@ class AlbumInfo(BaseModel):
     total_tracks: int
     uri: str
 
+
+class ArtistInfo(BaseModel):
+    """Artist information"""
+    id: str
+    name: str
+    genres: List[str] = []
+    followers: int = 0
+    popularity: int = 0
+    uri: str
+
 # Models for MCP manifest
 class MCPTool(BaseModel):
     """MCP tool"""
@@ -114,4 +124,4 @@ class MCPManifest(BaseModel):
     api: Dict[str, Any]
     contactEmail: Optional[str] = None
     legalInfoUrl: Optional[str] = None
-    tools: List[MCPTool] 
+    tools: List[MCPTool]

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -67,6 +67,7 @@ class MCPServer:
             "search_collections": self.controller.playback.search_collections,
             "get_playlists": self.controller.playlists.get_playlists,
             "get_playlist_tracks": self.controller.playlists.get_playlist_tracks,
+            "get_artist": self.controller.artists.get_artist,
             "get_album": self.controller.albums.get_album,
             "get_albums": self.controller.albums.get_albums,
             "get_album_tracks": self.controller.albums.get_album_tracks,
@@ -90,6 +91,7 @@ class MCPServer:
             "search_music": self._validate_search_music,
             "search_collections": self._validate_search_collections,
             "get_playlist_tracks": self._validate_get_playlist_tracks,
+            "get_artist": self._validate_get_artist,
             "get_album": self._validate_get_album,
             "get_albums": self._validate_get_albums,
             "get_album_tracks": self._validate_get_album_tracks,
@@ -113,6 +115,7 @@ class MCPServer:
             "search_collections": self._format_json_result,
             "get_playlists": self._format_json_result,
             "get_playlist_tracks": self._format_json_result,
+            "get_artist": self._format_json_result,
             "get_album": self._format_json_result,
             "get_albums": self._format_json_result,
             "get_album_tracks": self._format_json_result,
@@ -294,6 +297,15 @@ class MCPServer:
 
         # set default limit if not provided
         arguments.setdefault("limit", 20)
+
+    def _validate_get_artist(self, arguments: Dict[str, Any]):
+        artist_id = arguments.get("artist_id")
+        if not artist_id:
+            raise ValueError("artist_id is required")
+        if artist_id.isdigit() and len(artist_id) < 10:
+            raise ValueError(
+                "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes."
+            )
 
     def _validate_rename_playlist(self, arguments: Dict[str, Any]):
         if not arguments.get("playlist_id"):

--- a/src/mcp_spotify_player/spotify_client.py
+++ b/src/mcp_spotify_player/spotify_client.py
@@ -17,6 +17,7 @@ from mcp_spotify.errors import (
 from mcp_spotify_player.client_playback import SpotifyPlaybackClient
 from mcp_spotify_player.client_playlists import SpotifyPlaylistsClient
 from mcp_spotify_player.client_albums import SpotifyAlbumsClient
+from mcp_spotify_player.client_artists import SpotifyArtistsClient
 from mcp_spotify_player.config import Config
 
 
@@ -38,6 +39,7 @@ class SpotifyClient:
         self.playback = SpotifyPlaybackClient(self)
         self.playlists = SpotifyPlaylistsClient(self)
         self.albums = SpotifyAlbumsClient(self)
+        self.artists = SpotifyArtistsClient(self)
         self.verify_scopes = verify_scopes
         if verify_at_startup:
             tokens = self.tokens_provider()
@@ -115,7 +117,7 @@ class SpotifyClient:
         return data
 
     def __getattr__(self, name):
-        for client in (self.playback, self.playlists, self.albums):
+        for client in (self.playback, self.playlists, self.albums, self.artists):
             if hasattr(client, name):
                 return getattr(client, name)
         raise AttributeError(f"{self.__class__.__name__} object has no attribute {name}")

--- a/src/mcp_spotify_player/spotify_controller.py
+++ b/src/mcp_spotify_player/spotify_controller.py
@@ -8,6 +8,7 @@ from mcp_spotify_player.client_auth import is_token_expired
 from mcp_spotify_player.playback_controller import PlaybackController
 from mcp_spotify_player.playlist_controller import PlaylistController
 from mcp_spotify_player.album_controller import AlbumController
+from mcp_spotify_player.artists_controller import ArtistsController
 from mcp_spotify_player.spotify_client import SpotifyClient
 
 logger = get_logger(__name__)
@@ -25,6 +26,7 @@ class SpotifyController:
         self.playback = PlaybackController(self.client)
         self.playlists = PlaylistController(self.client)
         self.albums = AlbumController(self.client)
+        self.artists = ArtistsController(self.client)
 
     def is_authenticated(self) -> bool:
         """Checks if valid authentication tokens are available."""
@@ -42,4 +44,6 @@ class SpotifyController:
             return getattr(self.playlists, name)
         if hasattr(self.albums, name):
             return getattr(self.albums, name)
+        if hasattr(self.artists, name):
+            return getattr(self.artists, name)
         raise AttributeError(f"{self.__class__.__name__} object has no attribute {name}")

--- a/tests/test_get_artist_controller.py
+++ b/tests/test_get_artist_controller.py
@@ -1,0 +1,23 @@
+from mcp_spotify_player.artists_controller import ArtistsController
+
+
+def test_get_artist_controller():
+    class DummyArtists:
+        def get_artist(self, artist_id):
+            return {
+                "id": artist_id,
+                "name": "Test Artist",
+                "genres": ["rock"],
+                "followers": {"total": 1000},
+                "popularity": 50,
+                "uri": f"spotify:artist:{artist_id}",
+            }
+
+    dummy_client = type("Dummy", (), {"artists": DummyArtists()})()
+    controller = ArtistsController(dummy_client)
+
+    result = controller.get_artist("1234567890abc")
+    assert result["success"] is True
+    artist = result["artist"]
+    assert artist["name"] == "Test Artist"
+    assert artist["genres"][0] == "rock"

--- a/tests/test_get_artist_manifest.py
+++ b/tests/test_get_artist_manifest.py
@@ -1,0 +1,7 @@
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+
+
+def test_get_artist_in_stdio_manifest():
+    server = MCPServer()
+    tool_names = [tool["name"] for tool in server.manifest["tools"]]
+    assert "get_artist" in tool_names


### PR DESCRIPTION
## Summary
- add SpotifyArtistsClient and ArtistsController to retrieve artist details
- expose new get_artist tool in manifest, stdio server, and Spotify client
- document artist lookup in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0a6823b74832c95a9e76adf902d48