### PR TITLE
docs: update README scopes and project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,19 @@ If `MCP_SPOTIFY_TOKENS_PATH` is not set, tokens will be stored in
   "access_token": "ACCESS",
   "refresh_token": "REFRESH",
   "expires_at": 1700000000,
-  "scopes": ["user-read-playback-state", "user-modify-playback-state"]
+  "scopes": [
+    "user-read-playback-state",
+    "user-modify-playback-state",
+    "user-read-currently-playing",
+    "user-read-recently-played",
+    "user-read-playback-position",
+    "user-top-read",
+    "playlist-read-private",
+    "playlist-read-collaborative",
+    "playlist-modify-private",
+    "user-library-read",
+    "user-library-modify"
+  ]
 }
 ```
 
@@ -142,7 +154,8 @@ Parameters:
 
 | Feature | Scopes |
 | ------- | ------ |
-| Playback control & status | `user-read-playback-state`, `user-modify-playback-state`, `user-read-currently-playing` |
+| Playback control & status | `user-read-playback-state`, `user-modify-playback-state`, `user-read-currently-playing`, `user-read-playback-position` |
+| Playback insights | `user-read-recently-played`, `user-top-read` |
 | Playlist management | `playlist-read-private`, `playlist-read-collaborative`, `playlist-modify-private` |
 | Library access | `user-library-read`, `user-library-modify` |
 
@@ -153,10 +166,17 @@ Parameters:
 ```
 mcp-spotify-player/
 ├── src/
+│   ├── mcp_logging/
+│   │   └── __init__.py
+│   ├── mcp_spotify/
+│   │   ├── __init__.py
+│   │   └── errors.py
 │   └── mcp_spotify_player/
 │       ├── __init__.py
-│       ├── cli.py
 │       ├── __main__.py
+│       ├── album_controller.py
+│       ├── cli.py
+│       ├── client_albums.py
 │       ├── client_auth.py
 │       ├── client_playback.py
 │       ├── client_playlists.py


### PR DESCRIPTION
## Summary
- expand token file format with all OAuth scopes
- document current project structure
- restore original Python version requirement and redirect URI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0a6fbaf18832cb7e5556654832977