### PR TITLE
feat: regenerate tokens when missing

### DIFF
--- a/tests/auth/test_token_wiring.py
+++ b/tests/auth/test_token_wiring.py
@@ -1,26 +1,47 @@
 import json
-import json
-import json
 from pathlib import Path
 
 import pytest
+import requests
 
 from mcp_spotify.auth.tokens import Tokens
 from mcp_spotify.errors import (
     InvalidTokenFileError,
-    NotAuthenticatedError,
     RefreshNotPossibleError,
 )
 from mcp_spotify_player.client_auth import try_load_tokens
+from mcp_spotify_player.config import Config
 from mcp_spotify_player.spotify_client import SpotifyClient
 
 
 def test_no_tokens_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(tmp_path / "tokens.json"))
-    assert try_load_tokens() is None
-    client = SpotifyClient(lambda: None)
-    with pytest.raises(NotAuthenticatedError):
-        client.playback.get_playback_state()
+    path = tmp_path / "tokens.json"
+    monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(path))
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "id")
+    monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "secret")
+    monkeypatch.setattr(Config, "SPOTIFY_CLIENT_ID", "id")
+    monkeypatch.setattr(Config, "SPOTIFY_CLIENT_SECRET", "secret")
+
+    class DummyResponse:
+        def __init__(self, data):
+            self.status_code = 200
+            self._data = data
+            self.text = json.dumps(data)
+
+        def json(self):
+            return self._data
+
+    def fake_post(url, data):
+        assert data["grant_type"] == "client_credentials"
+        return DummyResponse({"access_token": "abc", "expires_in": 60})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    tokens = try_load_tokens()
+    assert tokens is not None
+    assert path.exists()
+    stored = json.loads(path.read_text())
+    assert stored["access_token"] == "abc"
 
 
 def test_invalid_token_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- auto-generate Spotify tokens file using client credentials when missing
- test token regeneration and persistence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0aca4bbac832c92ae19ec152bbd1d