### PR TITLE
Add artist top tracks retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Control your Spotify music from Claude using the MCP (Model Context Protocol).
 - **Album browsing**: View album details and track lists
 - **Artist info**: View artist details by ID
 - **Artist albums**: View albums of an artist by ID
+- **Artist top tracks**: View top tracks of an artist by ID
 - **Saved albums**: List albums saved in your library
 - **Check saved albums**: Verify if albums are in your library
 - **Save albums**: Add albums to your library
@@ -121,6 +122,7 @@ After authenticating with Spotify, you can use these commands in your MCP client
 - `get_playlist_tracks` — "Show tracks in playlist 'Road Trip'"
 - `get_artist` — "Show info about artist with a given ID"
 - `get_artist_albums` — "Show albums of an artist by ID"
+- `get_artist_top_tracks` — "Show top tracks of an artist by ID"
 - `get_album` — "Show info about album 'The Dark Side of the Moon'"
 - `get_albums` — "Show info about multiple albums"
 - `get_album_tracks` — "Show tracks in album 'The Dark Side of the Moon'"

--- a/src/mcp_spotify_player/client_artists.py
+++ b/src/mcp_spotify_player/client_artists.py
@@ -40,3 +40,19 @@ class SpotifyArtistsClient:
             "Response getting albums for artist id %s: %s", artist_id, result
         )
         return result
+
+    def get_artist_top_tracks(
+        self, artist_id: str, *, market: str = "US"
+    ) -> Optional[Dict[str, Any]]:
+        """Retrieve top tracks for a specific artist."""
+        logger.info(
+            "spotify_client -- Getting top tracks for artist id %s", artist_id
+        )
+        params: Dict[str, Any] = {"market": market}
+        result = self.requester._make_request(
+            "GET", f"/artists/{artist_id}/top-tracks", params=params
+        )
+        logger.debug(
+            "Response getting top tracks for artist id %s: %s", artist_id, result
+        )
+        return result

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -282,6 +282,31 @@ MANIFEST = {
             },
         },
         {
+            "name": "get_artist_top_tracks",
+            "description": "Retrieve top tracks for a given artist ID",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "artist_id": {
+                        "type": "string",
+                        "description": "Spotify artist ID",
+                    },
+                    "market": {
+                        "type": "string",
+                        "description": "ISO 3166-1 alpha-2 country code",
+                        "default": "US",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10,
+                        "default": 10,
+                    },
+                },
+                "required": ["artist_id"],
+            },
+        },
+        {
             "name": "get_album",
             "description": "Retrieve album information by its ID",
             "inputSchema": {

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -69,6 +69,7 @@ class MCPServer:
             "get_playlist_tracks": self.controller.playlists.get_playlist_tracks,
             "get_artist": self.controller.artists.get_artist,
             "get_artist_albums": self.controller.artists.get_artist_albums,
+            "get_artist_top_tracks": self.controller.artists.get_artist_top_tracks,
             "get_album": self.controller.albums.get_album,
             "get_albums": self.controller.albums.get_albums,
             "get_album_tracks": self.controller.albums.get_album_tracks,
@@ -94,6 +95,7 @@ class MCPServer:
             "get_playlist_tracks": self._validate_get_playlist_tracks,
             "get_artist": self._validate_get_artist,
             "get_artist_albums": self._validate_get_artist_albums,
+            "get_artist_top_tracks": self._validate_get_artist_top_tracks,
             "get_album": self._validate_get_album,
             "get_albums": self._validate_get_albums,
             "get_album_tracks": self._validate_get_album_tracks,
@@ -119,6 +121,7 @@ class MCPServer:
             "get_playlist_tracks": self._format_json_result,
             "get_artist": self._format_json_result,
             "get_artist_albums": self._format_json_result,
+            "get_artist_top_tracks": self._format_json_result,
             "get_album": self._format_json_result,
             "get_albums": self._format_json_result,
             "get_album_tracks": self._format_json_result,
@@ -324,6 +327,27 @@ class MCPServer:
                 raise ValueError("limit must be between 1 and 50")
         else:
             arguments["limit"] = 20
+
+    def _validate_get_artist_top_tracks(self, arguments: Dict[str, Any]):
+        artist_id = arguments.get("artist_id")
+        if not artist_id:
+            raise ValueError("artist_id is required")
+        if artist_id.isdigit() and len(artist_id) < 10:
+            raise ValueError(
+                "The provided identifier appears to be a position number, not a valid Spotify ID. Spotify IDs are long alphanumeric codes."
+            )
+        limit = arguments.get("limit")
+        if limit is not None:
+            if not isinstance(limit, int) or limit < 1 or limit > 10:
+                raise ValueError("limit must be between 1 and 10")
+        else:
+            arguments["limit"] = 10
+        market = arguments.get("market")
+        if market is not None:
+            if not isinstance(market, str) or len(market) != 2:
+                raise ValueError("market must be a 2-letter country code")
+        else:
+            arguments["market"] = "US"
 
     def _validate_rename_playlist(self, arguments: Dict[str, Any]):
         if not arguments.get("playlist_id"):

--- a/tests/test_get_artist_top_tracks_controller.py
+++ b/tests/test_get_artist_top_tracks_controller.py
@@ -1,0 +1,27 @@
+from mcp_spotify_player.artists_controller import ArtistsController
+
+
+def test_get_artist_top_tracks_controller():
+    class DummyArtists:
+        def get_artist_top_tracks(self, artist_id, market='US'):
+            return {
+                "tracks": [
+                    {
+                        "name": "Track 1",
+                        "artists": [{"name": "Artist 1"}],
+                        "album": {"name": "Album 1"},
+                        "uri": "spotify:track:track1",
+                        "duration_ms": 180000,
+                        "external_urls": {"spotify": "https://open.spotify.com/track/track1"},
+                    }
+                ]
+            }
+
+    dummy_client = type("Dummy", (), {"artists": DummyArtists()})()
+    controller = ArtistsController(dummy_client)
+
+    result = controller.get_artist_top_tracks("1234567890abc")
+    assert result["success"] is True
+    tracks = result["tracks"]
+    assert tracks[0]["name"] == "Track 1"
+    assert tracks[0]["artist"] == "Artist 1"

--- a/tests/test_get_artist_top_tracks_manifest.py
+++ b/tests/test_get_artist_top_tracks_manifest.py
@@ -1,0 +1,7 @@
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+
+
+def test_get_artist_top_tracks_in_stdio_manifest():
+    server = MCPServer()
+    tool_names = [tool["name"] for tool in server.manifest["tools"]]
+    assert "get_artist_top_tracks" in tool_names


### PR DESCRIPTION
## Summary
- support retrieving an artist's top tracks via Spotify API
- expose `get_artist_top_tracks` through MCP server and manifest
- document new command and add tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0b2ecea60832ca1b48fd1d5711e8a