### PR TITLE
Enforce user OAuth tokens and safer refresh handling

### DIFF
--- a/src/mcp_spotify/errors.py
+++ b/src/mcp_spotify/errors.py
@@ -21,6 +21,10 @@ class RefreshNotPossibleError(McpUserError):
     """Raised when refreshing the Spotify access token is not possible."""
 
 
+class UserAuthRequiredError(McpUserError):
+    """Raised when a user OAuth token with refresh capability is required."""
+
+
 class MissingScopesError(McpUserError):
     """Raised when the OAuth token lacks required scopes."""
 

--- a/tests/auth/test_token_refresh.py
+++ b/tests/auth/test_token_refresh.py
@@ -9,6 +9,7 @@ import requests
 
 from mcp_spotify.auth.tokens import Tokens
 from mcp_spotify.errors import RefreshNotPossibleError
+from mcp_spotify_player.client_auth import SpotifyAuthClient
 from mcp_spotify_player.spotify_client import SpotifyClient
 
 
@@ -67,16 +68,45 @@ def test_request_401_triggers_refresh(tmp_path: Path, monkeypatch: pytest.Monkey
     assert stored["access_token"] == "new"
 
 
-def test_missing_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    tokens = Tokens("a", "", 0)
+def test_make_request_401_without_refresh_token_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tokens = Tokens("a", "", int(time.time()) + 3600)
 
-    def fail_request(*args, **kwargs):  # pragma: no cover
-        raise AssertionError("request should not be made")
+    def fake_request(method, url, headers=None, **kwargs):
+        return DummyResponse(401)
 
-    monkeypatch.setattr(requests, "request", fail_request)
-    monkeypatch.setattr(requests, "post", fail_request)
+    def fail_post(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("refresh should not be attempted")
+
+    monkeypatch.setattr(requests, "request", fake_request)
+    monkeypatch.setattr(requests, "post", fail_post)
 
     client = SpotifyClient(lambda: tokens)
-    with pytest.raises(RefreshNotPossibleError):
+    with pytest.raises(RefreshNotPossibleError) as exc:
         client.playback.get_playback_state()
+    assert "missing refresh_token" in str(exc.value)
+
+
+def test_refresh_preserves_refresh_token_when_missing_in_response(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "tokens.json"
+    client = SpotifyAuthClient()
+    client.tokens_file = str(path)
+    client.access_token = "old"
+    client.refresh_token = "refresh"
+    client.token_expires_at = 0
+
+    def fake_post(url, data):
+        return DummyResponse(200, {"access_token": "new", "expires_in": 120})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(time, "time", lambda: 1000)
+
+    assert client.refresh_access_token() is True
+    assert client.refresh_token == "refresh"
+    stored = json.loads(path.read_text())
+    assert stored["refresh_token"] == "refresh"
+    assert client.token_expires_at == 1000 + 120 - 60
 

--- a/tests/auth/test_token_wiring.py
+++ b/tests/auth/test_token_wiring.py
@@ -1,47 +1,33 @@
 import json
+import os
 from pathlib import Path
 
 import pytest
-import requests
 
 from mcp_spotify.auth.tokens import Tokens
-from mcp_spotify.errors import (
-    InvalidTokenFileError,
-    RefreshNotPossibleError,
-)
-from mcp_spotify_player.client_auth import try_load_tokens
-from mcp_spotify_player.config import Config
+from mcp_spotify.errors import InvalidTokenFileError, UserAuthRequiredError
+from mcp_spotify_player.client_auth import SpotifyAuthClient, try_load_tokens
+from mcp_spotify_player.mcp_stdio_server import MCPServer
 from mcp_spotify_player.spotify_client import SpotifyClient
 
 
-def test_no_tokens_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    path = tmp_path / "tokens.json"
+def test_no_tokens_file_returns_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "alt" / "tokens.json"
     monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(path))
-    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "id")
-    monkeypatch.setenv("SPOTIFY_CLIENT_SECRET", "secret")
-    monkeypatch.setattr(Config, "SPOTIFY_CLIENT_ID", "id")
-    monkeypatch.setattr(Config, "SPOTIFY_CLIENT_SECRET", "secret")
-
-    class DummyResponse:
-        def __init__(self, data):
-            self.status_code = 200
-            self._data = data
-            self.text = json.dumps(data)
-
-        def json(self):
-            return self._data
-
-    def fake_post(url, data):
-        assert data["grant_type"] == "client_credentials"
-        return DummyResponse({"access_token": "abc", "expires_in": 60})
-
-    monkeypatch.setattr(requests, "post", fake_post)
 
     tokens = try_load_tokens()
-    assert tokens is not None
-    assert path.exists()
-    stored = json.loads(path.read_text())
-    assert stored["access_token"] == "abc"
+    assert tokens is None
+    assert not path.exists()
+
+
+def test_no_tokens_file_fails_without_creating_client_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "alt" / "tokens.json"
+    monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(path))
+    with pytest.raises(UserAuthRequiredError):
+        MCPServer()
+    assert not path.exists()
 
 
 def test_invalid_token_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -61,13 +47,22 @@ def test_invalid_token_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
         client.playback.get_playback_state()
 
 
-def test_missing_refresh_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_atomic_write_tokens_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = tmp_path / "tokens.json"
-    data = {"access_token": "a", "refresh_token": "", "expires_at": 0}
-    path.write_text(json.dumps(data))
-    monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(path))
-    tokens = try_load_tokens()
-    assert tokens is not None
-    client = SpotifyClient(lambda: tokens)
-    with pytest.raises(RefreshNotPossibleError):
-        client.playback.get_playback_state()
+    path.write_text(
+        json.dumps({"access_token": "a", "refresh_token": "r", "expires_at": 1})
+    )
+    client = SpotifyAuthClient()
+    client.tokens_file = str(path)
+    client.access_token = "b"
+    client.refresh_token = "r2"
+    client.token_expires_at = 2
+
+    def fail_replace(src, dst):
+        raise OSError("boom")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+    with pytest.raises(OSError):
+        client._save_tokens()
+    data = json.loads(path.read_text())
+    assert data["access_token"] == "a"

--- a/tests/auth/test_tokens_validation.py
+++ b/tests/auth/test_tokens_validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 
 import pytest
 
@@ -46,3 +47,11 @@ def test_valid_tokens(tmp_path: Path) -> None:
     assert tokens.access_token == "a"
     assert tokens.refresh_token == "r"
     assert tokens.expires_at == 1
+
+
+def test_load_tokens_minimal_shape_without_scopes(tmp_path: Path) -> None:
+    path = tmp_path / "tokens.json"
+    data = {"access_token": "a", "refresh_token": "r", "expires_at": 1}
+    path.write_text(json.dumps(data))
+    tokens = load_tokens(path)
+    assert tokens.scopes == set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _tokens_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "tokens.json"
+    data = {
+        "access_token": "test-token",
+        "refresh_token": "test-refresh",
+        "expires_at": int(time.time()) + 3600,
+    }
+    path.write_text(json.dumps(data))
+    monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(path))
+    yield

--- a/tests/test_search_collections.py
+++ b/tests/test_search_collections.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from unittest.mock import patch
 import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -77,8 +76,7 @@ def test_search_collections_album_with_market():
 # Validation tests
 
 def _server():
-    with patch("mcp_spotify_player.mcp_stdio_server.try_load_tokens", return_value=None):
-        return MCPServer()
+    return MCPServer()
 
 
 def test_validate_search_collections_invalid_type():


### PR DESCRIPTION
## Summary
- require user OAuth tokens with refresh_token; no more client-credentials bootstrap
- add helper to detect refresh tokens and ensure refresh preserves existing token
- perform atomic token writes and optional scopes handling

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1b282d10c832c8ed32316a23c2f30