### PR TITLE
feat: improve auth callback page

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,49 @@ Note: dependencies are managed with `pyproject.toml`.
 If `MCP_SPOTIFY_TOKENS_PATH` is not set, tokens will be stored in
    `~/.config/mcp_spotify_player/tokens.json` by default.
 
+## ⚡ Quick start
+
+1. Trigger the `/auth` command from your MCP client.
+2. A browser window opens for Spotify login. After approving access you will see a
+   confirmation page from **mcp-spotify-player** with a close button.
+3. Tokens are saved to `tokens.json` (by default under `~/.config/mcp_spotify_player/`).
+4. Back in your client, try a simple command like `get_current_playing` to verify
+   authentication.
+
+### What can I ask Claude?
+
+- `auth`
+- `play_music`
+- `pause_music`
+- `skip_next`
+- `skip_previous`
+- `set_volume`
+- `set_repeat`
+- `get_current_playing`
+- `get_playback_state`
+- `get_devices`
+- `search_music`
+- `search_collections`
+- `get_playlists`
+- `get_playlist_tracks`
+- `get_artist`
+- `get_artist_albums`
+- `get_artist_top_tracks`
+- `get_album`
+- `get_albums`
+- `get_album_tracks`
+- `get_saved_albums`
+- `check_saved_albums`
+- `save_albums`
+- `delete_saved_albums`
+- `create_playlist`
+- `rename_playlist`
+- `clear_playlist`
+- `add_tracks_to_playlist`
+- `queue_add`
+- `queue_list`
+- `diagnose`
+
 ### Token file format
 
 ```json
@@ -95,6 +138,20 @@ If `MCP_SPOTIFY_TOKENS_PATH` is not set, tokens will be stored in
   ]
 }
 ```
+
+## User Authentication (PKCE)
+
+The server uses Spotify's PKCE OAuth flow:
+
+1. A random `code_verifier` and its SHA-256 `code_challenge` are created.
+2. Your browser opens the Spotify authorization page.
+3. Spotify redirects back to `http://127.0.0.1:8000/auth/callback` where a local
+   handler completes the flow and displays a confirmation page.
+4. Access and refresh tokens are stored in `tokens.json` and refreshed as needed.
+
+Make sure your Spotify app configuration includes the redirect URI above and the
+required scopes from `env.example`. Set the `SPOTIFY_CLIENT_ID` and, if using
+the confidential flow, `SPOTIFY_CLIENT_SECRET` as environment variables.
 
 ## 🔐 Spotify Configuration
 
@@ -122,6 +179,7 @@ print(f"{name} – {artist}")
 
 After authenticating with Spotify, you can use these commands in your MCP client:
 
+- `auth` — "Authenticate with Spotify via browser"
 - `play_music` — "Play Bohemian Rhapsody"
 - `pause_music` — "Pause the music"
 - `skip_next` — "Next song"

--- a/src/mcp_spotify_player/client_auth.py
+++ b/src/mcp_spotify_player/client_auth.py
@@ -16,11 +16,67 @@ import requests
 from mcp_spotify.auth.tokens import Tokens, load_tokens, needs_refresh
 from mcp_spotify.errors import InvalidTokenFileError
 from mcp_spotify_player.config import Config, get_tokens_path
+from mcp_spotify_player.mcp_manifest import MANIFEST
 from mcp_logging import get_logger
 
 logger = get_logger(__name__)
 
 _CODE_VERIFIER: str | None = None
+
+APP_NAME = "mcp-spotify-player"
+GITHUB_URL = "https://github.com/victor-saez-gonzalez/mcp-spotify-player"
+COMMAND_NAMES = [
+    "auth",
+    "play_music",
+    "pause_music",
+    "skip_next",
+    "skip_previous",
+    "search_music",
+    "queue_add",
+    "get_current_playing",
+    "set_volume",
+]
+INITIAL_COMMANDS = [
+    tool["name"]
+    for tool in MANIFEST.get("tools", [])
+    if tool["name"] in COMMAND_NAMES
+]
+WELCOME_TEXT = (
+    "You've connected your Spotify account so the MCP tools can control playback, "
+    "search tracks, manage playlists and queue."
+)
+CLOSE_NOTE = "You can close this window and return to your client."
+
+
+def build_success_page(commands: list[str]) -> str:
+    items = "\n".join(f"<li><code>{cmd}</code></li>" for cmd in commands)
+    return f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\" />
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+<title>{APP_NAME}</title>
+<style>
+body{{font-family:sans-serif;max-width:600px;margin:2rem auto;padding:1rem;line-height:1.6;background:#fff;color:#111}}
+h1{{font-size:1.8rem;margin-bottom:1rem}}
+h2{{font-size:1.4rem;margin-top:2rem}}
+a{{color:#1DB954}}
+button{{margin-top:1rem;padding:0.5rem 1rem;font-size:1rem}}
+@media (prefers-reduced-motion: reduce){{*{{animation-duration:0s!important;transition:none!important}}}}
+</style>
+</head>
+<body>
+<h1>{APP_NAME}</h1>
+<p>{WELCOME_TEXT}</p>
+<p><a href=\"{GITHUB_URL}\">Project on GitHub</a></p>
+<h2>What can I do next?</h2>
+<ul>
+{items}
+</ul>
+<button type=\"button\" onclick=\"window.close()\">Close</button>
+<p>{CLOSE_NOTE}</p>
+</body>
+</html>"""
 
 
 def build_authorize_url(scopes: list[str], state: str, pkce: bool) -> str:
@@ -117,8 +173,10 @@ def ensure_user_tokens() -> None:
                 return
             code_holder["code"] = params["code"][0]
             self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
-            self.wfile.write(b"Authorization complete. You can close this window.")
+            html = build_success_page(INITIAL_COMMANDS)
+            self.wfile.write(html.encode("utf-8"))
             event.set()
             threading.Thread(target=self.server.shutdown, daemon=True).start()
 

--- a/tests/auth/test_callback_html.py
+++ b/tests/auth/test_callback_html.py
@@ -1,0 +1,39 @@
+import socket
+import threading
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from mcp_spotify_player.client_auth import INITIAL_COMMANDS, build_success_page
+
+
+def test_callback_serves_html():
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            html = build_success_page(INITIAL_COMMANDS)
+            self.wfile.write(html.encode("utf-8"))
+
+        def log_message(self, *args, **kwargs):
+            return
+
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+
+    httpd = HTTPServer(("127.0.0.1", port), Handler)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.start()
+
+    res = urllib.request.urlopen(f"http://127.0.0.1:{port}/")
+    html = res.read().decode()
+
+    httpd.shutdown()
+    thread.join()
+
+    assert res.status == 200
+    assert res.headers["Content-Type"] == "text/html; charset=utf-8"
+    assert "mcp-spotify-player" in html
+    assert "https://github.com/victor-saez-gonzalez/mcp-spotify-player" in html
+    assert any(cmd in html for cmd in INITIAL_COMMANDS)


### PR DESCRIPTION
## Summary
- serve branded HTML confirmation page on OAuth callback
- document PKCE auth flow and quick start steps
- add unit test for callback HTML
- list all available commands in README

## Testing
- `ruff check README.md` *(fails: SyntaxError from parsing Markdown)*
- `ruff check src tests` *(fails: F401, E401 in pre-existing tests)*
- `python -m pytest tests/auth/test_callback_html.py -q`
- `pytest -q` *(no output; process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b1a369a8832c818072791a9fd77c