### PR TITLE
feat: document JetBrains setup and show all tools after auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,35 @@ artist = current["item"]["artists"][0]["name"]
 print(f"{name} – {artist}")
 ```
 
+### Configuring MCP Server in PyCharm / IntelliJ
+
+JetBrains IDEs (PyCharm, IntelliJ, etc.) with GitHub Copilot have native support for MCP servers.
+
+1. Go to **File → Settings → GitHub Copilot → Model Context Protocol (MCP)**.
+2. On the right side, click **Configure** to edit the `mcp.json` file.
+3. Add the following snippet, replacing the paths and dummy credentials as needed:
+
+```json
+{
+  "servers": {
+    "spotify-player": {
+      "command": "C:/Users/YourUser/AppData/Local/Programs/Python/Python311/python.exe",
+      "args": ["-m", "mcp_spotify_player"],
+      "cwd": "Z:/projects/mcp/mcp-spotify-player",
+      "env": {
+        "SPOTIFY_CLIENT_ID": "your-client-id",
+        "SPOTIFY_CLIENT_SECRET": "your-client-secret",
+        "SPOTIFY_REDIRECT_URI": "http://127.0.0.1:8000/auth/callback"
+      }
+    }
+  }
+}
+```
+
+Replace `your-client-id` and `your-client-secret` with the credentials from your Spotify Developer Dashboard. **Do not commit your real credentials into version control.**
+
+Once configured, the server will appear in the Copilot Agent inside PyCharm/IntelliJ, and tools like `/auth`, `/play_music`, and `/pause_music` can be invoked directly.
+
 ## 🛠️ Commands
 
 After authenticating with Spotify, you can use these commands in your MCP client:

--- a/tests/auth/test_callback_html.py
+++ b/tests/auth/test_callback_html.py
@@ -3,7 +3,7 @@ import threading
 import urllib.request
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-from mcp_spotify_player.client_auth import INITIAL_COMMANDS, build_success_page
+from mcp_spotify_player.client_auth import ALL_COMMANDS, build_success_page
 
 
 def test_callback_serves_html():
@@ -12,7 +12,7 @@ def test_callback_serves_html():
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
-            html = build_success_page(INITIAL_COMMANDS)
+            html = build_success_page()
             self.wfile.write(html.encode("utf-8"))
 
         def log_message(self, *args, **kwargs):
@@ -36,4 +36,4 @@ def test_callback_serves_html():
     assert res.headers["Content-Type"] == "text/html; charset=utf-8"
     assert "mcp-spotify-player" in html
     assert "https://github.com/victor-saez-gonzalez/mcp-spotify-player" in html
-    assert any(cmd in html for cmd in INITIAL_COMMANDS)
+    assert all(cmd in html for cmd in ALL_COMMANDS)


### PR DESCRIPTION
## Summary
- document how to configure the server in JetBrains IDEs using GitHub Copilot's MCP integration
- display every manifest tool on the OAuth success page in a simple grid
- adjust callback HTML test to cover the full command list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b33b4a24d0832cbc06aa7b589effaa