### PR TITLE
fix: prevent double browser open during OAuth flow

### DIFF
--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -11,6 +11,11 @@ MANIFEST = {
     },
     "tools": [
         {
+            "name": "auth",
+            "description": "Authenticate with Spotify via OAuth",
+            "inputSchema": {"type": "object", "properties": {}}
+        },
+        {
             "name": "play_music",
             "description": "Play music on Spotify. You can specify a song, artist, playlist or simply resume playback.",
             "inputSchema": {

--- a/tests/auth/test_oauth_flow.py
+++ b/tests/auth/test_oauth_flow.py
@@ -1,0 +1,42 @@
+import time
+from unittest import mock
+
+import requests
+
+from mcp_spotify_player.mcp_stdio_server import MCPServer
+from mcp_spotify_player.config import Config
+
+
+def test_auth_flow_opens_browser_once(monkeypatch, tmp_path):
+    port = 8765
+    redirect = f"http://127.0.0.1:{port}/auth/callback"
+    monkeypatch.setenv("SPOTIFY_REDIRECT_URI", redirect)
+    monkeypatch.setenv("SPOTIFY_CLIENT_ID", "dummy")
+    monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(tmp_path / "tokens.json"))
+    monkeypatch.setattr(Config, "SPOTIFY_REDIRECT_URI", redirect)
+    monkeypatch.setattr(
+        "mcp_spotify_player.mcp_stdio_server.try_load_tokens", lambda: None
+    )
+
+    with mock.patch("webbrowser.open") as mock_open:
+        server = MCPServer()
+
+        result1 = server.execute_tool("auth", {})
+        assert "Opened browser" in result1
+
+        result2 = server.execute_tool("auth", {})
+        assert "already in progress" in result2
+        assert mock_open.call_count == 1
+
+        resp = requests.get(
+            f"http://127.0.0.1:{port}/auth/callback?code=abc",
+            proxies={"http": None, "https": None},
+        )
+        assert resp.status_code == 200
+
+        for _ in range(50):
+            if not server.oauth_flow.in_progress():
+                break
+            time.sleep(0.1)
+
+        assert mock_open.call_count == 1

--- a/tests/auth/test_token_wiring.py
+++ b/tests/auth/test_token_wiring.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from mcp_spotify.auth.tokens import Tokens
-from mcp_spotify.errors import InvalidTokenFileError, UserAuthRequiredError
+from mcp_spotify.errors import InvalidTokenFileError
 from mcp_spotify_player.client_auth import SpotifyAuthClient, try_load_tokens
 from mcp_spotify_player.mcp_stdio_server import MCPServer
 from mcp_spotify_player.spotify_client import SpotifyClient
@@ -20,13 +20,13 @@ def test_no_tokens_file_returns_none(tmp_path: Path, monkeypatch: pytest.MonkeyP
     assert not path.exists()
 
 
-def test_no_tokens_file_fails_without_creating_client_credentials(
+def test_no_tokens_file_does_not_create_client_credentials(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     path = tmp_path / "alt" / "tokens.json"
     monkeypatch.setenv("MCP_SPOTIFY_TOKENS_PATH", str(path))
-    with pytest.raises(UserAuthRequiredError):
-        MCPServer()
+    server = MCPServer()
+    assert server.current_tokens is None
     assert not path.exists()
 
 


### PR DESCRIPTION
## Summary
- start OAuth flow only via `/auth` tool with single browser open guard
- expose new `auth` tool in server and manifest instead of opening browser on startup
- add regression test covering auth callback and single browser launch

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3405a83f0832ca40959cf1a05378b