### PR TITLE
docs(core): translate architecture docs to English

### DIFF
--- a/docs/architecture/ADR-001-core-boundaries.md
+++ b/docs/architecture/ADR-001-core-boundaries.md
@@ -1,0 +1,49 @@
+# ADR-001: Transport-agnostic core separation
+
+- **Status**: Proposed
+- **Date**: 2025-09-17
+
+## Context
+
+We must evolve the MCP Spotify player into a dual server (stdio + streamable HTTP) without duplicating business rules or control logic. The current code couples transport concerns (stdio framing, HTTP socket handling) with the MCP execution flow, making it difficult to enable new transports, test domain logic, and keep stable contracts with clients. Supporting two adapters simultaneously demands clear responsibility boundaries to avoid regressions between modes.
+
+## Decision
+
+We will define a **transport-agnostic core** that encapsulates MCP logic and Spotify business operations, delegating input/output and server lifecycle management to specific adapters (stdio and HTTP). The core will expose pure interfaces and already-deserialized MCP models so that it can be reused by any transport.
+
+### Core responsibilities
+
+- Register and describe MCP tools available to clients.
+- Route and execute MCP calls against Spotify controllers without performing transport input/output.
+- Perform minimal validation of already-deserialized MCP requests (required parameters, basic types, tool schemas).
+- Build MCP success and error responses, normalizing shared metadata.
+- Map Spotify domain errors to the typed MCP errors defined in the core taxonomy.
+
+### Out of scope for the core (adapter responsibilities)
+
+- Full management of I/O and framing (stdio, HTTP, headers, chunked encoding, sockets).
+- Transport-level authentication (Bearer tokens), header `Origin`/CORS validation, and any channel-specific policy.
+- Marshalling between bytes and JSON as well as orchestration of server lifecycle and network configuration.
+
+### Allowed dependencies within the core
+
+- Internal types and utilities that do not couple the core to any transport.
+- Abstract interfaces to the Spotify client.
+- No server frameworks, direct environment access, or dependencies with network side effects.
+
+## Alternatives considered
+
+1. **Transport-bound core**: keep the logic attached to the existing stdio model. Rejected because it prevents HTTP support without duplicating logic and triggers regressions across transports.
+2. **Duplicated logic per transport**: build two complete pipelines (stdio and HTTP) with separate implementations. Rejected due to higher maintenance cost, behavioral inconsistencies, and increased error surface.
+3. **Event-driven core with shared buses**: introduce an internal messaging framework. Rejected as over-engineering for the current scope and for introducing unnecessary dependencies.
+
+## Consequences
+
+- **Positive**: reusable and stable core contracts; easier testing of MCP logic without transport dependencies; alignment with the dual-transport strategy. Enables future adapters to iterate quickly.
+- **Risks**: regressions if adapters do not faithfully replicate stdio framing; hidden coupling with the Spotify client; incorrect error mapping.
+
+## Mitigations
+
+- Define transport-specific contract test suites to validate framing and backward compatibility.
+- Establish clear interfaces for the Spotify client and review them with the domain team before implementation.
+- Document and automate the error taxonomy so that each adapter respects the codes and semantics defined by the core.

--- a/docs/architecture/checklist-phase-1.1.md
+++ b/docs/architecture/checklist-phase-1.1.md
@@ -1,0 +1,8 @@
+# Phase 1.1 checklist
+
+- [ ] ADR approved (`ADR-001-core-boundaries.md`).
+- [ ] Core interfaces described and transport-decoupled (`core-interfaces.md`).
+- [ ] MCP models agreed with examples (`mcp-models-contract.md`).
+- [ ] Configuration and logging policy defined (`core-config-and-logging.md`).
+- [ ] Error taxonomy approved (`error-taxonomy.json`).
+- [ ] Note: Phase 1.2 can be implemented without touching these contracts.

--- a/docs/architecture/core-config-and-logging.md
+++ b/docs/architecture/core-config-and-logging.md
@@ -1,0 +1,29 @@
+# Core configuration and logging
+
+## CoreConfig contract
+
+`CoreConfig` is injected by adapters with resolved values. It must include:
+
+- `token_store_path`: filesystem or secret location managed outside the core.
+- `required_scopes`: list of Spotify scopes the business operations need.
+- `preferred_device`: optional logical device identifier for playback.
+- `business_timeouts`: dictionary of operation → milliseconds.
+- `default_locale`: locale code used when the request context omits it.
+
+Adapters are responsible for reading environment variables, feature flags, or configuration files. The core receives sanitized values and must not access process environment or CLI flags directly.
+
+## Logging policy
+
+Structured logging is mandatory. Minimum fields:
+
+| Field | Description |
+| --- | --- |
+| `timestamp` | ISO-8601 instant provided by the logger implementation. |
+| `level` | Severity (`info`, `warn`, `error`, etc.). |
+| `area` | Logical subsystem (e.g., `core.dispatcher`, `core.spotify`). |
+| `message` | Short event description. |
+| `correlation_id` | Propagated from `ExecutionContext`. |
+| `tool_name` | Present for tool invocations; empty otherwise. |
+| `duration_ms` | Execution time in milliseconds when relevant. |
+
+The core must never write to stdout/stderr directly. All logging goes through the injected logger, which adapts to each transport’s observability stack.

--- a/docs/architecture/core-interfaces.md
+++ b/docs/architecture/core-interfaces.md
@@ -1,0 +1,73 @@
+# MCP core interfaces
+
+The core operates on already-deserialized MCP models and assumes no transport detail. All interfaces are stable contracts for adapters (stdio, HTTP) and domain providers (Spotify).
+
+## ToolRegistry
+
+Manager of tools exposed by the MCP server.
+
+- `register(tool: ToolDefinition) -> None`: adds or updates an available tool.
+- `unregister(name: str) -> None`: removes an existing tool.
+- `list() -> List[ToolDefinition]`: returns the full registered definitions.
+- `describe(name: str) -> ToolDefinition | None`: fetches the definition of a specific tool.
+
+Requirements:
+- In-memory or pluggable persistence with no access to transport layers.
+- Validate unique name, input schema, and description before registering.
+
+## Dispatcher
+
+Primary orchestrator of MCP calls.
+
+- `dispatch(request: McpMessage, ctx: ExecutionContext) -> McpResponse`
+
+Expected behavior:
+- Select the appropriate operation (initialize, tools/list, tool.call, etc.).
+- Invoke `ToolRegistry` and Spotify controllers when needed.
+- Propagate `correlation_id` to logs and responses.
+- Always return an `McpResponse` instance (success or typed error).
+
+## ExecutionContext
+
+Operational context associated with every request.
+
+Mandatory fields:
+- `request_id: str`
+- `correlation_id: str`
+- `time_budget_ms: int`
+- `locale: str`
+
+Optional fields:
+- `user: Optional[UserIdentity]` (abstract identifier resolved by the adapter).
+
+Notes:
+- The context is immutable for the core; any extension must be documented via new fields.
+- Adapters resolve timeouts and cancellations, notifying the core if operations must be aborted.
+
+## SpotifyController (port)
+
+Abstract interface that encapsulates domain operations against Spotify. Adapters provide concrete implementations that comply with authentication and transport policies.
+
+High-level operations (typed inputs and outputs):
+- `play(target: PlayTarget, options: PlayOptions) -> PlaybackState`
+- `pause() -> PlaybackState`
+- `queue(item: QueueItem) -> QueueState`
+- `search(query: SearchQuery) -> SearchResults`
+- `list_playlists(owner: OwnerRef, page: PageRequest) -> PlaylistPage`
+
+Characteristics:
+- The core never manages tokens or network retries directly.
+- Types such as `PlayTarget`, `PlayOptions`, `PlaybackState`, etc. are transport-independent domain models.
+
+## Abstract logger
+
+The core relies on an injected logger with the following operations:
+
+- `info(event: str, fields: Dict[str, Any]) -> None`
+- `warn(event: str, fields: Dict[str, Any]) -> None`
+- `error(event: str, fields: Dict[str, Any]) -> None`
+
+Rules:
+- `fields` must include `correlation_id` when available.
+- The core performs no string formatting; only key/value pairs are passed through.
+- The logger does not write directly to process stdout/stderr; adapters decide the sink (files, observability, etc.).

--- a/docs/architecture/error-taxonomy.json
+++ b/docs/architecture/error-taxonomy.json
@@ -1,0 +1,53 @@
+{
+  "BadRequest": {
+    "code": "BadRequest",
+    "httpHint": 400,
+    "retryable": false,
+    "description": "Invalid or incomplete parameters after core-level validation.",
+    "data": {
+      "schemaRef": "#/$defs/validation"
+    }
+  },
+  "Unauthorized": {
+    "code": "Unauthorized",
+    "httpHint": 401,
+    "retryable": false,
+    "description": "The adapter indicates the user is unauthenticated or the token expired."
+  },
+  "Forbidden": {
+    "code": "Forbidden",
+    "httpHint": 403,
+    "retryable": false,
+    "description": "The authenticated user lacks required permissions or scopes for the action.",
+    "data": {
+      "schemaRef": "#/$defs/authorization"
+    }
+  },
+  "NotFound": {
+    "code": "NotFound",
+    "httpHint": 404,
+    "retryable": false,
+    "description": "The requested resource (e.g., device, playlist, track) does not exist or is not visible."
+  },
+  "Conflict": {
+    "code": "Conflict",
+    "httpHint": 409,
+    "retryable": false,
+    "description": "Inconsistent state detected by the core or Spotify (e.g., concurrent playback)."
+  },
+  "RateLimited": {
+    "code": "RateLimited",
+    "httpHint": 429,
+    "retryable": true,
+    "description": "The operation exceeded quotas enforced by Spotify or internal policies.",
+    "data": {
+      "schemaRef": "#/$defs/rate-limit"
+    }
+  },
+  "Internal": {
+    "code": "Internal",
+    "httpHint": 500,
+    "retryable": true,
+    "description": "Unexpected error within the core or failure reported by dependent services."
+  }
+}

--- a/docs/architecture/mcp-models-contract.md
+++ b/docs/architecture/mcp-models-contract.md
@@ -1,0 +1,155 @@
+# MCP models contract
+
+The transport determines framing and low-level serialization. The core models describe logical structures after JSON parsing.
+
+## Core models
+
+- `McpMessage`
+  - `method: str`
+  - `params: Dict[str, Any]` with schema validation handled before reaching the core.
+- `ToolDefinition`
+  - `name: str`
+  - `description: str`
+  - `input_schema: JsonSchema`
+  - `output_schema: JsonSchema`
+- `ToolCall`
+  - `name: str`
+  - `arguments: Dict[str, Any]`
+- `McpResponse`
+  - `Success`
+    - `result: Any`
+    - `meta: Optional[Dict[str, Any]]`
+  - `Error`
+    - `code: str`
+    - `message: str`
+    - `data: Optional[Dict[str, Any]]`
+
+## Contract examples
+
+Examples show logical payloads. Transports may embed them in frames or envelopes as needed.
+
+### initialize
+
+```json
+{
+  "id": "req-001",
+  "method": "initialize",
+  "params": {
+    "client": {
+      "name": "spotify-cli",
+      "version": "1.4.0"
+    },
+    "capabilities": {
+      "streaming": true,
+      "max_chunk": 65536
+    }
+  }
+}
+```
+
+### tools/list
+
+```json
+{
+  "id": "req-105",
+  "method": "tools/list",
+  "params": {}
+}
+```
+
+Sample response:
+
+```json
+{
+  "id": "req-105",
+  "result": {
+    "tools": [
+      {
+        "name": "play",
+        "description": "Start playback on the preferred device",
+        "input_schema": {
+          "type": "object",
+          "required": ["uri"],
+          "properties": {
+            "uri": {
+              "type": "string",
+              "format": "spotify"
+            },
+            "start_position_ms": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "output_schema": {
+          "type": "object",
+          "properties": {
+            "playback_state": {
+              "$ref": "#/definitions/PlaybackState"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "meta": {
+    "generated_at": "2025-09-17T11:42:00Z"
+  }
+}
+```
+
+### tool.call (`play` example)
+
+Request:
+
+```json
+{
+  "id": "req-512",
+  "method": "tool.call",
+  "params": {
+    "tool": "play",
+    "arguments": {
+      "uri": "spotify:track:6rqhFgbbKwnb9MLmUQDhG6",
+      "start_position_ms": 15000
+    }
+  }
+}
+```
+
+Success response:
+
+```json
+{
+  "id": "req-512",
+  "result": {
+    "playback_state": {
+      "track_uri": "spotify:track:6rqhFgbbKwnb9MLmUQDhG6",
+      "is_playing": true,
+      "position_ms": 15000,
+      "device": "desktop-player"
+    }
+  },
+  "meta": {
+    "correlation_id": "corr-512",
+    "duration_ms": 84
+  }
+}
+```
+
+Error response:
+
+```json
+{
+  "id": "req-512",
+  "error": {
+    "code": "NotFound",
+    "message": "Requested track or device is not available",
+    "data": {
+      "missing": "device",
+      "schema": {
+        "$ref": "#/definitions/DeviceUnavailable"
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
## Resumen
- Added ADR-001 documenting the separation of the transport-agnostic core.
- Defined the interfaces, models and configuration/logging policies of the MCP core.
- Documented the error taxonomy and acceptance checklist for Phase 1.1.
- Content updated in English and with corrected ADR date

## Checklist Fase 1.1
- [ ] ADR approved (ADR-001-core-boundaries.md).
- [ ] Core interfaces described and decoupled from transport (core-interfaces.md).
- [ ] MCP models agreed with examples (mcp-models-contract.md).
- [ ] Configuration and logging policy defined (core-config-and-logging.md).
- [ ] Error taxonomy approved (error-taxonomy.json).
- [ ] Note: Phase 1.2 can be implemented without touching these contracts.

## Target branch
feature/dual-transport
