### PR TITLE
Add reorder_playlist_tracks tool

### DIFF
--- a/src/mcp_spotify_player/client_playlists.py
+++ b/src/mcp_spotify_player/client_playlists.py
@@ -81,3 +81,25 @@ class SpotifyPlaylistsClient:
         )
         logger.debug("Response adding tracks to playlist %s: %s", playlist_id, result)
         return result is not None
+
+    def reorder_playlist_tracks(
+        self,
+        playlist_id: str,
+        range_start: int,
+        insert_before: int,
+        range_length: int = 1,
+    ) -> bool:
+        """Reorder tracks in a playlist"""
+        logger.info("spotify_client -- Reordering tracks in playlist %s", playlist_id)
+        result = self.requester._make_request(
+            'PUT',
+            f'/playlists/{playlist_id}/tracks',
+            feature='playlists',
+            json={
+                'range_start': range_start,
+                'insert_before': insert_before,
+                'range_length': range_length,
+            },
+        )
+        logger.debug("Response reordering tracks in playlist %s: %s", playlist_id, result)
+        return result is not None

--- a/src/mcp_spotify_player/mcp_manifest.py
+++ b/src/mcp_spotify_player/mcp_manifest.py
@@ -504,6 +504,40 @@ MANIFEST = {
             }
         },
         {
+            "name": "reorder_playlist_tracks",
+            "description": "Reorder tracks in a Spotify playlist. Moves a range of tracks to a new position.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "playlist_id": {
+                        "type": "string",
+                        "description": "Spotify playlist ID"
+                    },
+                    "range_start": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "The position of the first track to be reordered (zero-indexed)"
+                    },
+                    "insert_before": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "The position where the tracks should be inserted (zero-indexed)"
+                    },
+                    "range_length": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "default": 1,
+                        "description": "The number of tracks to be reordered (default: 1)"
+                    }
+                },
+                "required": [
+                    "playlist_id",
+                    "range_start",
+                    "insert_before"
+                ]
+            }
+        },
+        {
             "name": "diagnose",
             "description": "Display diagnostic information about authentication and environment",
             "inputSchema": {"type": "object", "properties": {}}

--- a/src/mcp_spotify_player/mcp_stdio_server.py
+++ b/src/mcp_spotify_player/mcp_stdio_server.py
@@ -87,6 +87,7 @@ class MCPServer:
             "clear_playlist": self.controller.playlists.clear_playlist,
             "create_playlist": self.controller.playlists.create_playlist,
             "add_tracks_to_playlist": self.controller.playlists.add_tracks_to_playlist,
+            "reorder_playlist_tracks": self.controller.playlists.reorder_playlist_tracks,
             "diagnose": self._diagnose,
             "queue_add": self.controller.playback.queue_add,
             "queue_list": self.controller.playback.queue_list,
@@ -114,6 +115,7 @@ class MCPServer:
             "clear_playlist": self._validate_clear_playlist,
             "create_playlist": self._validate_create_playlist,
             "add_tracks_to_playlist": self._validate_add_tracks_to_playlist,
+            "reorder_playlist_tracks": self._validate_reorder_playlist_tracks,
             "queue_add": self._validate_queue_add,
             "queue_list": self._validate_queue_list,
         }
@@ -449,6 +451,15 @@ class MCPServer:
     def _validate_add_tracks_to_playlist(self, arguments: Dict[str, Any]):
         if not arguments.get("playlist_id") or not arguments.get("track_uris"):
             raise ValueError("playlist_id and track_uris are required")
+
+    def _validate_reorder_playlist_tracks(self, arguments: Dict[str, Any]):
+        if not arguments.get("playlist_id"):
+            raise ValueError("playlist_id is required")
+        if arguments.get("range_start") is None:
+            raise ValueError("range_start is required")
+        if arguments.get("insert_before") is None:
+            raise ValueError("insert_before is required")
+        arguments.setdefault("range_length", 1)
 
     def _validate_queue_add(self, args: dict) -> None:
         """Validate input for the queue_add tool."""

--- a/src/mcp_spotify_player/playlist_controller.py
+++ b/src/mcp_spotify_player/playlist_controller.py
@@ -134,6 +134,28 @@ class PlaylistController:
         except Exception as e:
             return {'success': False, 'message': f'Error: {str(e)}'}
 
+    def reorder_playlist_tracks(
+        self, playlist_id: str, range_start: int, insert_before: int, range_length: int = 1
+    ) -> Dict[str, Any]:
+        """Reorder tracks in a playlist"""
+        try:
+            if not self._validate_spotify_id(playlist_id):
+                return {'success': False, 'message': 'Invalid playlist ID. It must be a valid Spotify ID.'}
+            if not isinstance(range_start, int) or range_start < 0:
+                return {'success': False, 'message': 'range_start must be a non-negative integer.'}
+            if not isinstance(insert_before, int) or insert_before < 0:
+                return {'success': False, 'message': 'insert_before must be a non-negative integer.'}
+            if not isinstance(range_length, int) or range_length < 1:
+                return {'success': False, 'message': 'range_length must be a positive integer.'}
+            result = self.playlists_client.reorder_playlist_tracks(
+                playlist_id, range_start, insert_before, range_length
+            )
+            if result:
+                return {'success': True, 'message': 'Playlist tracks reordered successfully'}
+            return {'success': False, 'message': 'Could not reorder playlist tracks'}
+        except Exception as e:
+            return {'success': False, 'message': f'Error: {str(e)}'}
+
     def _validate_spotify_id(self, id_string: str) -> bool:
         """Validates if the string is a valid Spotify ID"""
         return bool(id_string) and len(id_string) > 10 and all(c.isalnum() for c in id_string)


### PR DESCRIPTION
## Summary
- Add new `reorder_playlist_tracks` MCP tool that enables moving tracks within a Spotify playlist
- Calls Spotify's `PUT /playlists/{playlist_id}/tracks` API with `range_start`, `insert_before`, and `range_length` parameters
- Wired up across all four layers: API client, controller (with validation), manifest (tool schema), and server dispatch

## Test plan
- [x] All 81 existing tests pass
- [ ] Manually test reordering tracks in a playlist via Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)